### PR TITLE
Move the logic of directive detection outside of the walkcontainer utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,13 @@ export { PluginOptions, Mode, Source, PluginStringMap, Autorename } from '@types
 
 const transformer = (options: PluginOptions = {}): Transformer  => (
     (css: Root): void => {
-        initStore(options);     
+        initStore(options);
         parseKeyFrames(css);
         parseAtRules(css);
         parseRules(css);
         appendRules();
         appendKeyFrames();
-        appendAutorenameRules();      
+        appendAutorenameRules();
     }
 );
 

--- a/src/utilities/directives.ts
+++ b/src/utilities/directives.ts
@@ -1,5 +1,5 @@
 import { Comment } from 'postcss';
-import { ControlDirective } from '@types';
+import { ObjectWithProps, ControlDirective } from '@types';
 import { RTL_CONTROL_DIRECTIVE_REG_EXP, CONTROL_DIRECTIVE, CONTROL_DIRECTIVE_BLOCK } from '@constants';
 
 const CONTROL_DIRECTIVE_VALUES = Object.values(CONTROL_DIRECTIVE) as string[];
@@ -7,10 +7,10 @@ const CONTROL_DIRECTIVE_BLOCK_VALUES = Object.values(CONTROL_DIRECTIVE_BLOCK) as
 
 export const isValidMatchDirective = (match: (string | number | undefined)[]): boolean =>
     CONTROL_DIRECTIVE_VALUES.includes(`${match[2]}`) &&
-        (
-            match[1] === undefined ||
-            CONTROL_DIRECTIVE_BLOCK_VALUES.includes(`${match[1]}`)
-        );  
+    (
+        match[1] === undefined ||
+        CONTROL_DIRECTIVE_BLOCK_VALUES.includes(`${match[1]}`)
+    );  
 
 export const getControlDirective = (comment: Comment): ControlDirective | null => {
     const commentStr = comment.toString();
@@ -30,14 +30,34 @@ export const getControlDirective = (comment: Comment): ControlDirective | null =
     return null;
 };
 
-export const resetDirective = (directive: ControlDirective): void => {
-    if (directive.block === CONTROL_DIRECTIVE_BLOCK.END) {
-        directive.directive = null;
-        directive.block = null;
-    } else {
-        if (directive.block !== CONTROL_DIRECTIVE_BLOCK.BEGIN) {
-            directive.directive = null;
-            directive.block = null;
+export const isIgnoreDirectiveInsideAnIgnoreBlock = (
+    controlDirective: ControlDirective,
+    controlDirectives: ObjectWithProps<ControlDirective>
+): boolean => (
+    controlDirective.directive === CONTROL_DIRECTIVE.IGNORE &&
+    !controlDirective.block &&
+    controlDirectives[CONTROL_DIRECTIVE.IGNORE] &&
+    controlDirectives[CONTROL_DIRECTIVE.IGNORE].block === CONTROL_DIRECTIVE_BLOCK.BEGIN
+);
+
+export const checkDirective = (controlDirectives: ObjectWithProps<ControlDirective>, directiveType: string): boolean => {
+
+    const directive = controlDirectives[directiveType];
+
+    if (directive) {
+
+        const { block } = directive;
+
+        if (block !== CONTROL_DIRECTIVE_BLOCK.BEGIN) {
+            delete controlDirectives[directiveType];
         }
+
+        if (block !== CONTROL_DIRECTIVE_BLOCK.END) {
+            return true;
+        }
+
     }
+
+    return false;
+
 };

--- a/tests/__snapshots__/combined-autorename.test.ts.snap
+++ b/tests/__snapshots__/combined-autorename.test.ts.snap
@@ -184,6 +184,22 @@ exports[`Combined Tests Autorename Combined Autorename: flexible 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -547,6 +563,22 @@ exports[`Combined Tests Autorename Combined Autorename: flexible with custom str
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {
@@ -914,6 +946,22 @@ exports[`Combined Tests Autorename Combined Autorename: flexible, greedy: true 1
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1277,6 +1325,22 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives 
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {
@@ -1644,6 +1708,22 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives,
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -2009,6 +2089,22 @@ exports[`Combined Tests Autorename Combined Autorename: strict 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -2372,6 +2468,22 @@ exports[`Combined Tests Autorename Combined Autorename: strict, greedy: true 1`]
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/__snapshots__/combined-basic-options.test.ts.snap
+++ b/tests/__snapshots__/combined-basic-options.test.ts.snap
@@ -186,6 +186,22 @@ exports[`Combined Tests Basic Options Combined {processKeyFrames: true} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip-ltr {
     from {
         transform: translateX(100px);
@@ -587,6 +603,22 @@ exports[`Combined Tests Basic Options Combined {processUrls: true} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -952,6 +984,22 @@ exports[`Combined Tests Basic Options Combined {source: rtl, processKeyFrames: t
     animation: 5s flip-ltr 1s ease-in-out,
                3s my-animation-ltr 6s ease-in-out;
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    right: 10px;
 }
 
 @keyframes flip-rtl {
@@ -1351,6 +1399,22 @@ exports[`Combined Tests Basic Options Combined {source: rtl} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1718,6 +1782,22 @@ exports[`Combined Tests Basic Options Combined {useCalc: true} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -2081,6 +2161,22 @@ exports[`Combined Tests Basic Options Combined Basic 1`] = `
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/__snapshots__/combined-prefixes.test.ts.snap
+++ b/tests/__snapshots__/combined-prefixes.test.ts.snap
@@ -184,6 +184,22 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.ltr .test18::after {
+    left: 10px;
+}
+
+.rtl .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -557,6 +573,22 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix propert
 
 .rtl .test18, .right-to-left .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.ltr .test18::after, .left-to-right .test18::after {
+    left: 10px;
+}
+
+.rtl .test18::after, .right-to-left .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {
@@ -936,6 +968,22 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix, rtlPrefix, and bothP
 
 .rtl .test18, .right-to-left .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.ltr .test18::after, .left-to-right .test18::after {
+    left: 10px;
+}
+
+.rtl .test18::after, .right-to-left .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/__snapshots__/combined-string-map.test.ts.snap
+++ b/tests/__snapshots__/combined-string-map.test.ts.snap
@@ -188,6 +188,22 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -555,6 +571,22 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {
@@ -926,6 +958,22 @@ exports[`Combined Tests String Map Combined custom string map and processUrls: t
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1293,6 +1341,22 @@ exports[`Combined Tests String Map Combined custom string map without names and 
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/__snapshots__/override-autorename.test.ts.snap
+++ b/tests/__snapshots__/override-autorename.test.ts.snap
@@ -165,6 +165,20 @@ exports[`Override Tests Autorename Override Autorename: flexible 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -497,6 +511,20 @@ exports[`Override Tests Autorename Override Autorename: flexible with custom str
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {
@@ -833,6 +861,20 @@ exports[`Override Tests Autorename Override Autorename: flexible, greedy: true 1
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1165,6 +1207,20 @@ exports[`Override Tests Autorename Override Autorename: only control directives 
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {
@@ -1501,6 +1557,20 @@ exports[`Override Tests Autorename Override Autorename: only control directives,
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1835,6 +1905,20 @@ exports[`Override Tests Autorename Override Autorename: strict 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -2167,6 +2251,20 @@ exports[`Override Tests Autorename Override Autorename: strict, greedy: true 1`]
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/__snapshots__/override-basic-options.test.ts.snap
+++ b/tests/__snapshots__/override-basic-options.test.ts.snap
@@ -167,6 +167,20 @@ exports[`Override Tests Basic Options Override {processKeyFrames: true} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip-ltr {
     from {
         transform: translateX(100px);
@@ -531,6 +545,20 @@ exports[`Override Tests Basic Options Override {processUrls: true} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -865,6 +893,20 @@ exports[`Override Tests Basic Options Override {source: rtl, processKeyFrames: t
     animation: 5s flip-ltr 1s ease-in-out,
                3s my-animation-ltr 6s ease-in-out;
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip-rtl {
@@ -1227,6 +1269,20 @@ exports[`Override Tests Basic Options Override {source: rtl} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1563,6 +1619,20 @@ exports[`Override Tests Basic Options Override {useCalc: true} 1`] = `
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1895,6 +1965,20 @@ exports[`Override Tests Basic Options Override Basic 1`] = `
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/__snapshots__/override-prefixes.test.ts.snap
+++ b/tests/__snapshots__/override-prefixes.test.ts.snap
@@ -165,6 +165,20 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.rtl .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -502,6 +516,20 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
 
 .rtl .test18, .right-to-left .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.rtl .test18::after, .right-to-left .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {
@@ -845,6 +873,20 @@ exports[`Override Tests Prefixes Override custom ltrPrefix, rtlPrefix, and bothP
 
 .rtl .test18, .right-to-left .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.rtl .test18::after, .right-to-left .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/__snapshots__/override-string-map.test.ts.snap
+++ b/tests/__snapshots__/override-string-map.test.ts.snap
@@ -169,6 +169,20 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -505,6 +519,20 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {
@@ -845,6 +873,20 @@ exports[`Override Tests String Map Override custom string map and processUrls: t
     padding: 10px 10px 40px 20px;
 }
 
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
+}
+
 @keyframes flip {
     from {
         transform: translateX(100px);
@@ -1181,6 +1223,20 @@ exports[`Override Tests String Map Override custom string map without names and 
 
 [dir=\\"rtl\\"] .test18 {
     padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] .test18::after {
+    left: unset;
+    right: 10px;
 }
 
 @keyframes flip {

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -73,6 +73,7 @@
     text-align: right;
 }
 
+/*rtl:ignore*/
 .test14 .test15 span {
     border-left-color: #777;
     margin: 10px 20px 30px 40px;
@@ -106,6 +107,18 @@
                3s my-animation 6s ease-in-out;
     font-size: 10px;
     padding: 10px 20px 40px 10px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    /*rtl:begin:ignore*/
+    text-align: left;
+    padding-left: 5px;
+    /*rtl:ignore*/
+    margin-left: 15px;
+    transform: translateX(5px);
+    /*rtl:end:ignore*/
 }
 
 @keyframes flip {


### PR DESCRIPTION
To prepare the plugin to manage other control directives, it is necessary to move the logic about control directive detection outside of the WalkContainer utility, so, the directives will be managed separated for each parser.