### PR TITLE
This commit implements the RTL raw control directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.5.0] - 2020-04-30
+
+- Implemented RTL raw control directives for rules and declarations
+
 ## [1.4.0] - 2020-04-24
 
 - Implemented RTL rename control directives for rules and declarations

--- a/README.md
+++ b/README.md
@@ -982,14 +982,15 @@ Control Directives
 
 Control directives are placed between rules or declarations. They can target a single node or a set of nodes.
 
-| Directive                | Description                                                                        |
-| ------------------------ | ---------------------------------------------------------------------------------- |
-| `/*rtl:ignore*/`         | Ignores processing of the following rule or declaration                            |
-| `/*rtl:begin:ignore*/`   | Starts an ignoring block                                                           |
-| `/*rtl:end:ignore*/`     | Ends an ignoring block                                                             |
-| `/*rtl:rename*/`         | This directive forces renaming in the next rule or declaration no mattering the value of the properties `processUrls` or `autoRename` |
-| `/*rtl:begin:rename*/`   | Starts a renaming block                                                            |
-| `/*rtl:end:rename*/`     | Ends a renaming block                                                              |
+| Directive                | Description                                                                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/*rtl:ignore*/`         | Ignores processing of the following rule or declaration                                                                                        |
+| `/*rtl:begin:ignore*/`   | Starts an ignoring block                                                                                                                       |
+| `/*rtl:end:ignore*/`     | Ends an ignoring block                                                                                                                         |
+| `/*rtl:rename*/`         | This directive forces renaming in the next rule or declaration no mattering the value of the properties `processUrls` or `autoRename`          |
+| `/*rtl:begin:rename*/`   | Starts a renaming block                                                                                                                        |
+| `/*rtl:end:rename*/`     | Ends a renaming block                                                                                                                          |
+| `/*rtl:raw:{CSS}*/`      | Parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed `CSS` will be treated as `rtl` or `ltr` |
 
 ---
 
@@ -1222,6 +1223,70 @@ These directives should be used together, they will provide the beginning and th
 [dir="rtl"] .test {
     background-image: url("/images/background-right.png");
     cursor: url("/images/cursor-rtl.png");
+}
+```
+
+</p>
+
+</details>
+
+---
+
+#### `/*rtl:raw:{CSS}*/`
+
+<details><summary>Expand</summary>
+<p>
+
+Parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed CSS will be treated as `rtl` or `ltr`:
+
+##### input
+
+```css
+.test1 {
+    color: #EFEFEF;
+    left: 10px;
+    /*rtl:raw:
+    height: 50px;
+    width: 100px;*/
+}
+
+/*rtl:raw:.test2 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.test3 {
+    transform: translate(10px, 20px);
+}
+*/
+```
+
+##### output
+
+```css
+.test1 {
+    color: #EFEFEF;
+}
+
+[dir="ltr"] .test1 {
+    left: 10px;
+}
+
+[dir="rtl"] .test1 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir="rtl"] .test2 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir="rtl"] .test3 {
+    transform: translate(10px, 20px);
 }
 ```
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,7 +13,8 @@ export const FLIP_PROPERTY_REGEXP = /(right|left)/i;
 
 export enum CONTROL_DIRECTIVE {
     IGNORE = 'ignore',
-    RENAME = 'rename'
+    RENAME = 'rename',
+    RAW = 'raw'
 }
 
 export enum CONTROL_DIRECTIVE_BLOCK {

--- a/src/parsers/declarations.ts
+++ b/src/parsers/declarations.ts
@@ -57,6 +57,16 @@ export const parseDeclarations = (rule: Rule, autorenamed = false): void => {
             cleanRuleRawsBefore(comment.next());              
             comment.remove(); 
 
+            if (controlDirective.directive === CONTROL_DIRECTIVE.RAW && controlDirective.raw) {
+                const root = postcss.parse(controlDirective.raw);
+                if (mode === Mode.combined) {
+                    ruleFlippedSecond.append(root.nodes);
+                } else {
+                    ruleFlipped.append(root.nodes);
+                }
+                
+            }
+
             if (isIgnoreDirectiveInsideAnIgnoreBlock(controlDirective, controlDirectives)) {
                 return;
             }

--- a/src/parsers/rules.ts
+++ b/src/parsers/rules.ts
@@ -1,20 +1,31 @@
-import { Container, Node, Rule, Comment } from 'postcss';
-import { ObjectWithProps, ControlDirective } from '@types';
+import postcss, { Container, Node, Rule, Comment } from 'postcss';
+import { ObjectWithProps, ControlDirective, Source } from '@types';
 import { RULE_TYPE, CONTROL_DIRECTIVE } from '@constants';
 import { store } from '@data/store';
 import { isIgnoreDirectiveInsideAnIgnoreBlock, checkDirective } from '@utilities/directives';
 import { walkContainer } from '@utilities/containers';
 import { cleanRuleRawsBefore } from '@utilities/rules';
+import { addSelectorPrefixes } from '@utilities/selectors';
 import { parseDeclarations } from './declarations';
 
 export const parseRules = (container: Container): void => {
 
     const controlDirectives: ObjectWithProps<ControlDirective> = {};
+    const { source, ltrPrefix, rtlPrefix } = store.options;
 
     walkContainer(
         container,
         [ RULE_TYPE ],
         (comment: Comment, controlDirective: ControlDirective): void => {
+
+            if (controlDirective.directive === CONTROL_DIRECTIVE.RAW && controlDirective.raw) {
+                const root = postcss.parse(controlDirective.raw);
+                root.walkRules((rule: Rule): void => {
+                    addSelectorPrefixes(rule, source === Source.ltr ? rtlPrefix : ltrPrefix);
+                });
+                comment.replaceWith(root.nodes);
+                return;
+            }
 
             cleanRuleRawsBefore(comment.next());              
             comment.remove(); 

--- a/src/utilities/directives.ts
+++ b/src/utilities/directives.ts
@@ -22,9 +22,9 @@ export const getControlDirective = (comment: Comment): ControlDirective | null =
         if (match[1]) {
             controlDirective.block = match[1];
         }
-        /*if (match[3]) {
+        if (match[3]) {
             controlDirective.raw = match[3];
-        }*/
+        }
         return controlDirective;
     }
     return null;

--- a/tests/__snapshots__/combined-autorename.test.ts.snap
+++ b/tests/__snapshots__/combined-autorename.test.ts.snap
@@ -378,6 +378,30 @@ exports[`Combined Tests Autorename Combined Autorename: flexible 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -759,6 +783,30 @@ exports[`Combined Tests Autorename Combined Autorename: flexible with custom str
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1140,6 +1188,30 @@ exports[`Combined Tests Autorename Combined Autorename: flexible, greedy: true 1
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1521,6 +1593,30 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives 
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1902,6 +1998,30 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives,
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -2283,6 +2403,30 @@ exports[`Combined Tests Autorename Combined Autorename: strict 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -2664,5 +2808,29 @@ exports[`Combined Tests Autorename Combined Autorename: strict, greedy: true 1`]
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/__snapshots__/combined-basic-options.test.ts.snap
+++ b/tests/__snapshots__/combined-basic-options.test.ts.snap
@@ -412,6 +412,30 @@ exports[`Combined Tests Basic Options Combined {processKeyFrames: true} 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -797,6 +821,30 @@ exports[`Combined Tests Basic Options Combined {processUrls: true} 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1212,6 +1260,30 @@ exports[`Combined Tests Basic Options Combined {source: rtl, processKeyFrames: t
 
 [dir=\\"ltr\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"ltr\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"ltr\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1593,6 +1665,30 @@ exports[`Combined Tests Basic Options Combined {source: rtl} 1`] = `
 
 [dir=\\"ltr\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"ltr\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"ltr\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1976,6 +2072,30 @@ exports[`Combined Tests Basic Options Combined {useCalc: true} 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -2357,5 +2477,29 @@ exports[`Combined Tests Basic Options Combined Basic 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/__snapshots__/combined-prefixes.test.ts.snap
+++ b/tests/__snapshots__/combined-prefixes.test.ts.snap
@@ -378,6 +378,30 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix 1`] = `
 
 .rtl .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+.ltr .test33 {
+    left: 10px;
+}
+
+.rtl .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -769,6 +793,30 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix propert
 
 .rtl .test32, .right-to-left .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+.ltr .test33, .left-to-right .test33 {
+    left: 10px;
+}
+
+.rtl .test33, .right-to-left .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl .example34, .right-to-left .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl .example35, .right-to-left .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1164,5 +1212,29 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix, rtlPrefix, and bothP
 
 .rtl .test32, .right-to-left .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+.ltr .test33, .left-to-right .test33 {
+    left: 10px;
+}
+
+.rtl .test33, .right-to-left .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl .example34, .right-to-left .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl .example35, .right-to-left .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/__snapshots__/combined-string-map.test.ts.snap
+++ b/tests/__snapshots__/combined-string-map.test.ts.snap
@@ -382,6 +382,30 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -767,6 +791,30 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1152,6 +1200,30 @@ exports[`Combined Tests String Map Combined custom string map and processUrls: t
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1537,5 +1609,29 @@ exports[`Combined Tests String Map Combined custom string map without names and 
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/__snapshots__/override-autorename.test.ts.snap
+++ b/tests/__snapshots__/override-autorename.test.ts.snap
@@ -345,6 +345,28 @@ exports[`Override Tests Autorename Override Autorename: flexible 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -693,6 +715,28 @@ exports[`Override Tests Autorename Override Autorename: flexible with custom str
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1041,6 +1085,28 @@ exports[`Override Tests Autorename Override Autorename: flexible, greedy: true 1
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1389,6 +1455,28 @@ exports[`Override Tests Autorename Override Autorename: only control directives 
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1737,6 +1825,28 @@ exports[`Override Tests Autorename Override Autorename: only control directives,
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -2085,6 +2195,28 @@ exports[`Override Tests Autorename Override Autorename: strict 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -2433,5 +2565,27 @@ exports[`Override Tests Autorename Override Autorename: strict, greedy: true 1`]
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/__snapshots__/override-basic-options.test.ts.snap
+++ b/tests/__snapshots__/override-basic-options.test.ts.snap
@@ -373,6 +373,28 @@ exports[`Override Tests Basic Options Override {processKeyFrames: true} 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -725,6 +747,28 @@ exports[`Override Tests Basic Options Override {processUrls: true} 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1101,6 +1145,28 @@ exports[`Override Tests Basic Options Override {source: rtl, processKeyFrames: t
 
 [dir=\\"ltr\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"ltr\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"ltr\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1449,6 +1515,28 @@ exports[`Override Tests Basic Options Override {source: rtl} 1`] = `
 
 [dir=\\"ltr\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"ltr\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"ltr\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1799,6 +1887,28 @@ exports[`Override Tests Basic Options Override {useCalc: true} 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -2147,5 +2257,27 @@ exports[`Override Tests Basic Options Override Basic 1`] = `
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/__snapshots__/override-prefixes.test.ts.snap
+++ b/tests/__snapshots__/override-prefixes.test.ts.snap
@@ -345,6 +345,28 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
 
 .rtl .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+.rtl .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -698,6 +720,28 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
 
 .rtl .test32, .right-to-left .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+.rtl .test33, .right-to-left .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl .example34, .right-to-left .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl .example35, .right-to-left .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1055,5 +1099,27 @@ exports[`Override Tests Prefixes Override custom ltrPrefix, rtlPrefix, and bothP
 
 .rtl .test32, .right-to-left .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+.rtl .test33, .right-to-left .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl .example34, .right-to-left .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl .example35, .right-to-left .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/__snapshots__/override-string-map.test.ts.snap
+++ b/tests/__snapshots__/override-string-map.test.ts.snap
@@ -349,6 +349,28 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -701,6 +723,28 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1053,6 +1097,28 @@ exports[`Override Tests String Map Override custom string map and processUrls: t
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;
 
@@ -1405,5 +1471,27 @@ exports[`Override Tests String Map Override custom string map without names and 
 
 [dir=\\"rtl\\"] .test32 {
     background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .test33 {
+    left: unset;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .example35 {
+    transform: translate(10px, 20px);
 }"
 `;

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -273,3 +273,22 @@
     /*rtl:end:rename*/
     border: 1px solid gray;    
 }
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+    /*rtl:raw:
+    height: 50px;
+    width: 100px;*/
+}
+
+/*rtl:raw:.example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.example35 {
+    transform: translate(10px, 20px);
+}
+*/


### PR DESCRIPTION
This directive parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed `CSS` will be treated as `rtl` or `ltr`:

##### input

```css
.test1 {
    color: #EFEFEF;
    left: 10px;
    /*rtl:raw:
    height: 50px;
    width: 100px;*/
}

/*rtl:raw:.test2 {
    color: #EFEFEF;
    left: 10px;
    width: 100%;    
}

.test3 {
    transform: translate(10px, 20px);
}
*/
```

##### output

```css
.test1 {
    color: #EFEFEF;
}

[dir="ltr"] .test1 {
    left: 10px;
}

[dir="rtl"] .test1 {
    right: 10px;
    height: 50px;
    width: 100px;
}

[dir="rtl"] .test2 {
    color: #EFEFEF;
    left: 10px;
    width: 100%;    
}

[dir="rtl"] .test3 {
    transform: translate(10px, 20px);
}
```