### PR TITLE
Fix Webpack configuration in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ rules: [
             {
                 loader: 'postcss-loader',
                 options: {
-                    ident: 'postcss',
-                    plugins: () => [ require('postcss-rtlcss')(options) ]
+                    postcssOptions: {
+                        plugins: [
+                            postcssRTLCSS(options)
+                        ]
+                    }
                 }
             }
         ]


### PR DESCRIPTION
The Webpack configuration example in the README file was pointing in an old configuration and with a wrong usage of the package.

This merge request fixes this.