### PR TITLE
Add support for nested rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.2.0] - 2021-03-13
+
+- Add basic support for nested rules (SCSS)
+
 ## [3.0.1] - 2021-02-19
 
 - In the override method change the `unset` value to override properties by the intial value of them to support the override method in Internet Explorer

--- a/src/parsers/declarations.ts
+++ b/src/parsers/declarations.ts
@@ -1,6 +1,6 @@
 import postcss, { Rule, Node, Declaration, Comment } from 'postcss';
 import rtlcss from 'rtlcss';
-import { Source, Mode, Autorename, ControlDirective } from '@types';
+import { Mode, Autorename, ControlDirective } from '@types';
 import {
     DECLARATION_TYPE,
     FLIP_PROPERTY_REGEXP,
@@ -9,22 +9,31 @@ import {
     CONTROL_DIRECTIVE
 } from '@constants';
 import { store } from '@data/store';
-import { addSelectorPrefixes } from '@utilities/selectors';
 import { isIgnoreDirectiveInsideAnIgnoreBlock, checkDirective } from '@utilities/directives';
-import { declarations, allDeclarations, initialValues, appendDeclarationToRule, hasIgnoreDirectiveInRaws } from '@utilities/declarations';
+import {
+    declarations,
+    allDeclarations,
+    initialValues,
+    appendDeclarationToRule,
+    hasIgnoreDirectiveInRaws
+} from '@utilities/declarations';
 import { walkContainer } from '@utilities/containers';
-import { cleanRuleRawsBefore } from '@utilities/rules';
+import {
+    cleanRuleRawsBefore,
+    insertRuleIntoStore,
+    appendParentRuleToStore
+} from '@utilities/rules';
 import { vendor } from '@utilities/vendor';
 
-export const parseDeclarations = (rule: Rule, autorenamed = false): void => {
+export const parseDeclarations = (
+    rule: Rule,
+    hasParentRule: boolean,
+    autorenamed = false
+): void => {
 
     const {
         mode,
-        ltrPrefix,
-        rtlPrefix,
-        bothPrefix,
         safeBothPrefix,
-        source,
         processUrls,
         useCalc,
         stringMap,
@@ -33,11 +42,10 @@ export const parseDeclarations = (rule: Rule, autorenamed = false): void => {
     } = store.options;
 
     const deleteDeclarations: Declaration[] = [];
-
     const ruleFlipped = rule.clone().removeAll();
     const ruleFlippedSecond = ruleFlipped.clone();
     const ruleBoth = ruleFlipped.clone();
-    const ruleSafe = ruleFlipped.clone();
+    const ruleSafe = ruleFlipped.clone();   
 
     const declarationHashMap = Array.prototype.reduce.call(rule.nodes, (obj: Record<string, string>, node: Node): Record<string, string> => {
         if (node.type === DECLARATION_TYPE) {
@@ -223,28 +231,36 @@ export const parseDeclarations = (rule: Rule, autorenamed = false): void => {
         deleteDeclarations.forEach((decl: Declaration): Declaration => decl.remove());
     }
 
-    if (ruleFlipped.nodes.length || ruleFlippedSecond.nodes.length || ruleBoth.nodes.length || ruleSafe.nodes.length) {
+    if (
+        ruleFlipped.nodes.length ||
+        ruleFlippedSecond.nodes.length ||
+        ruleBoth.nodes.length ||
+        ruleSafe.nodes.length
+    ) {
 
-        if (mode === Mode.combined) {
-            addSelectorPrefixes(ruleFlipped, source === Source.ltr ? ltrPrefix : rtlPrefix);
-            addSelectorPrefixes(ruleFlippedSecond, source === Source.rtl ? ltrPrefix : rtlPrefix);
+        if (hasParentRule) {            
+            appendParentRuleToStore(
+                rule,
+                ruleFlipped,
+                ruleFlippedSecond,
+                ruleBoth,
+                ruleSafe
+            );
         } else {
-            addSelectorPrefixes(ruleFlipped, source === Source.ltr ? rtlPrefix : ltrPrefix);
-            addSelectorPrefixes(ruleFlippedSecond, source === Source.rtl ? rtlPrefix : ltrPrefix);
+            insertRuleIntoStore(
+                rule,
+                ruleFlipped,
+                ruleFlippedSecond,
+                ruleBoth,
+                ruleSafe
+            );
         }
 
-        addSelectorPrefixes(ruleBoth, bothPrefix);
-        addSelectorPrefixes(ruleSafe, bothPrefix);
-
-        store.rules.push({
-            rule,
-            ruleLTR: ruleFlipped,
-            ruleRTL: ruleFlippedSecond,
-            ruleBoth,
-            ruleSafe
-        });
-
-    } else if (autoRename !== Autorename.disabled && !simetricRules && !autorenamed) {
+    } else if (
+        autoRename !== Autorename.disabled &&
+        !simetricRules &&
+        !autorenamed
+    ) {
         store.rulesAutoRename.push(rule);
     }
 

--- a/src/parsers/rules.ts
+++ b/src/parsers/rules.ts
@@ -8,7 +8,7 @@ import { cleanRuleRawsBefore } from '@utilities/rules';
 import { addSelectorPrefixes } from '@utilities/selectors';
 import { parseDeclarations } from './declarations';
 
-export const parseRules = (container: Container): void => {
+export const parseRules = (container: Container, hasParentRule = false): void => {
 
     const controlDirectives: Record<string, ControlDirective> = {};
     const { source, ltrPrefix, rtlPrefix } = store.options;
@@ -47,10 +47,12 @@ export const parseRules = (container: Container): void => {
 
             if (checkDirective(controlDirectives, CONTROL_DIRECTIVE.RENAME)) {
                 store.rulesAutoRename.push(rule);
-                parseDeclarations(rule, true);
+                parseDeclarations(rule, hasParentRule, true);
             } else {
-                parseDeclarations(rule);
-            }           
+                parseDeclarations(rule, hasParentRule);
+            }
+            
+            parseRules(rule, true);
         
         }
     );    

--- a/src/utilities/rules.ts
+++ b/src/utilities/rules.ts
@@ -1,7 +1,164 @@
 import { Rule, AtRule, Node, Declaration } from 'postcss';
-import { StringMap, Autorename } from '@types';
-import { COMMENT_TYPE, RTL_COMMENT_REGEXP, DECLARATION_TYPE, RULE_TYPE } from '@constants';
+import { StringMap, Autorename, RulesObject } from '@types';
+import {
+    COMMENT_TYPE,
+    RTL_COMMENT_REGEXP,
+    DECLARATION_TYPE,
+    RULE_TYPE
+} from '@constants';
 import { store } from '@data/store';
+import { addProperSelectorPrefixes } from '@utilities/selectors';
+
+export const ruleHasDeclarations = (rule: Rule): boolean => {
+    return rule.some(
+        (node: Node) => node.type === DECLARATION_TYPE
+    );
+};
+
+export const ruleHasChildren = (rule: Rule): boolean => {
+    return rule.some(
+        (node: Node) => (
+            node.type === DECLARATION_TYPE ||
+            (
+                node.type === RULE_TYPE &&
+                ruleHasChildren(node as Rule)
+            )
+        )
+    );
+};
+
+export const getParentRules = (rule: Rule): Rule[] => {
+    const rules: Rule[] = [];
+    while (rule.type === RULE_TYPE) {
+        rules.push(rule);
+        rule = rule.parent as Rule;  
+    }
+    rules.shift();
+    return rules.reverse();
+};
+
+export const insertRules = (
+    parent: Rule,
+    rule: Rule,
+    rules: Rule[]
+): void => {
+    if (ruleHasDeclarations(rule)) {
+        rules = [...rules];
+        let parentRule: Rule;
+        while (rules.length) {
+            parentRule = rules.shift();
+            const innerRule = parent.nodes.find((node: Node): boolean => {
+                if (
+                    node.type === RULE_TYPE &&
+                    (node as Rule).selector === parentRule.selector
+                ) {
+                    return true;
+                }
+            }) as Rule | undefined;
+            if (innerRule) {
+                parentRule = innerRule;
+            } else {
+                parentRule = parentRule.clone().removeAll();
+                parent.append(parentRule);
+            }
+            parent = parentRule;
+        }
+        parent.append(rule);
+    }
+};
+
+export const appendRulesToRuleObject = (
+    ruleFlipped: Rule,
+    ruleFlippedSecond: Rule,
+    ruleBoth: Rule,
+    ruleSafe: Rule,
+    ruleObject: RulesObject,
+    rules: Rule[]
+): void => {
+    insertRules(
+        ruleObject.ruleLTR,
+        ruleFlipped,
+        rules
+    );
+    insertRules(
+        ruleObject.ruleRTL,
+        ruleFlippedSecond,
+        rules
+    );
+    insertRules(
+        ruleObject.ruleBoth,
+        ruleBoth,
+        rules
+    );
+    insertRules(
+        ruleObject.ruleSafe,
+        ruleSafe,
+        rules
+    );
+};
+
+export const insertRuleIntoStore = (
+    rule: Rule,
+    ruleFlipped: Rule,
+    ruleFlippedSecond: Rule,
+    ruleBoth: Rule,
+    ruleSafe: Rule
+): RulesObject => {
+    const rulesObject = {
+        rule,
+        ruleLTR: ruleFlipped,
+        ruleRTL: ruleFlippedSecond,
+        ruleBoth,
+        ruleSafe
+    };
+    addProperSelectorPrefixes(
+        ruleFlipped,
+        ruleFlippedSecond,
+        ruleBoth,
+        ruleSafe
+    );
+    store.rules.push(rulesObject);
+    return rulesObject;
+};
+
+export const appendParentRuleToStore = (
+    rule: Rule,
+    ruleFlipped: Rule,
+    ruleFlippedSecond: Rule,
+    ruleBoth: Rule,
+    ruleSafe: Rule
+): void => {
+    
+    const rules = getParentRules(rule);
+    const root = rules.shift();
+
+    let rootRulesObject: RulesObject | undefined = store.rules.find(
+        (rObject: RulesObject) => rObject.rule === root
+    );
+    if (!rootRulesObject) {
+        const rootRuleFlipped = root.clone().removeAll();
+        const rootRuleFlippedSecond = rootRuleFlipped.clone();
+        const rootRuleBoth = rootRuleFlipped.clone();
+        const rootRruleSafe = rootRuleFlipped.clone();
+        rootRulesObject = insertRuleIntoStore(
+            root,
+            rootRuleFlipped,
+            rootRuleFlippedSecond,
+            rootRuleBoth,
+            rootRruleSafe
+        );    
+    }
+
+    appendRulesToRuleObject(
+        ruleFlipped,
+        ruleFlippedSecond,
+        ruleBoth,
+        ruleSafe,
+        rootRulesObject,
+        rules
+    );
+    
+};
 
 export const cleanRuleRawsBefore = (node: Node | void): void => {
     if (node && node.type === RULE_TYPE) {
@@ -27,6 +184,19 @@ export const cleanRules = (...rules: (Rule | AtRule | undefined | null)[]): void
     });
 };
 
+export const removeEmptyRules = (rule: Rule): void => {
+    if (ruleHasChildren(rule)) {
+        rule.walkRules((r: Rule): void => {
+            removeEmptyRules(r);
+            if (!ruleHasChildren(r)) {
+                r.remove();
+            }
+        });
+    } else {
+        rule.remove();
+    }
+};
+
 export const appendRules = (): void => {
     const { rules } = store; 
     rules.forEach(({rule, ruleLTR, ruleRTL, ruleBoth, ruleSafe}): void => {
@@ -34,10 +204,7 @@ export const appendRules = (): void => {
         ruleRTL && ruleRTL.nodes.length && rule.after(ruleRTL);
         ruleLTR && ruleLTR.nodes.length && rule.after(ruleLTR);
         ruleSafe && ruleSafe.nodes.length && rule.after(ruleSafe);
-        const ruleHasDeclarations = rule.some((node: Node) => node.type === DECLARATION_TYPE);      
-        if (!ruleHasDeclarations) {
-            rule.remove();
-        }
+        removeEmptyRules(rule);
         cleanRules(rule, ruleLTR, ruleRTL, ruleBoth, ruleSafe);
     }); 
 };

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -1,5 +1,6 @@
 import { Rule } from 'postcss';
-import { strings } from '@types';
+import { strings, Mode, Source } from '@types';
+import { store } from '@data/store';
 
 export const addSelectorPrefixes = (rule: Rule, prefixes: strings): void => {
     rule.selectors = typeof prefixes === 'string'
@@ -8,4 +9,29 @@ export const addSelectorPrefixes = (rule: Rule, prefixes: strings): void => {
             selectors = selectors.concat(prefixes.map((prefix: string): string => `${prefix} ${selector}`));
             return selectors;
         }, []);
+};
+
+export const addProperSelectorPrefixes = (
+    ruleFlipped: Rule,
+    ruleFlippedSecond: Rule,
+    ruleBoth: Rule,
+    ruleSafe: Rule
+): void => {
+    const {
+        mode,
+        ltrPrefix,
+        rtlPrefix,
+        bothPrefix,
+        source
+    } = store.options;
+    if (mode === Mode.combined) {
+        addSelectorPrefixes(ruleFlipped, source === Source.ltr ? ltrPrefix : rtlPrefix);
+        addSelectorPrefixes(ruleFlippedSecond, source === Source.rtl ? ltrPrefix : rtlPrefix);
+    } else {
+        addSelectorPrefixes(ruleFlipped, source === Source.ltr ? rtlPrefix : ltrPrefix);
+        addSelectorPrefixes(ruleFlippedSecond, source === Source.rtl ? rtlPrefix : ltrPrefix);
+    }
+
+    addSelectorPrefixes(ruleBoth, bothPrefix);
+    addSelectorPrefixes(ruleSafe, bothPrefix);
 };

--- a/tests/__snapshots__/combined-nested-rules.test.ts.snap
+++ b/tests/__snapshots__/combined-nested-rules.test.ts.snap
@@ -1,0 +1,221 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Combined Tests Nested rules Combined {source: ltr} 1`] = `
+".test1 {
+    color: red;
+    .test2 {
+        padding: 5px;
+        width: 100%;
+    }
+}
+
+[dir=\\"ltr\\"] .test1 {
+    left: 10px;
+    .test2 {
+        text-align: left;
+    }
+}
+
+[dir=\\"rtl\\"] .test1 {
+    right: 10px;
+    .test2 {
+        text-align: right;
+    }
+}
+
+.test3 {
+    &.test4 {
+        color: black;
+    }
+    &.test5 {
+        padding: 5px
+    }
+}
+
+[dir=\\"ltr\\"] .test3 {
+    left: 10px;
+    &.test4 {
+        margin-left: 20px;
+    }
+    &.test5 {
+        span {
+            text-align: left;
+        }
+    }
+}
+
+[dir=\\"rtl\\"] .test3 {
+    right: 10px;
+    &.test4 {
+        margin-right: 20px;
+    }
+    &.test5 {
+        span {
+            text-align: right;
+        }
+    }
+}
+
+.test6 {
+    display: flex;
+    .global & {
+        color: white;
+        div {
+            margin: 0 auto;
+        }
+    }
+    .test7 {
+        .global & {
+            background-color: #FFF;
+            ::after {
+                content: \\"\\";
+                display: block;
+            }
+        }
+    }
+}
+
+[dir=\\"ltr\\"] .test6 {
+    .global & {
+        padding: 5px 10px 5px 5px;
+        border-left-color: #666;
+        div {
+            padding-left: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            ::after {
+                text-align: left;
+            }
+        }
+    }
+}
+
+[dir=\\"rtl\\"] .test6 {
+    .global & {
+        padding: 5px 5px 5px 10px;
+        border-right-color: #666;
+        div {
+            padding-right: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            ::after {
+                text-align: right;
+            }
+        }
+    }
+}"
+`;
+
+exports[`Combined Tests Nested rules Combined {source: rtl} 1`] = `
+".test1 {
+    color: red;
+    .test2 {
+        padding: 5px;
+        width: 100%;
+    }
+}
+
+[dir=\\"rtl\\"] .test1 {
+    left: 10px;
+    .test2 {
+        text-align: left;
+    }
+}
+
+[dir=\\"ltr\\"] .test1 {
+    right: 10px;
+    .test2 {
+        text-align: right;
+    }
+}
+
+.test3 {
+    &.test4 {
+        color: black;
+    }
+    &.test5 {
+        padding: 5px
+    }
+}
+
+[dir=\\"rtl\\"] .test3 {
+    left: 10px;
+    &.test4 {
+        margin-left: 20px;
+    }
+    &.test5 {
+        span {
+            text-align: left;
+        }
+    }
+}
+
+[dir=\\"ltr\\"] .test3 {
+    right: 10px;
+    &.test4 {
+        margin-right: 20px;
+    }
+    &.test5 {
+        span {
+            text-align: right;
+        }
+    }
+}
+
+.test6 {
+    display: flex;
+    .global & {
+        color: white;
+        div {
+            margin: 0 auto;
+        }
+    }
+    .test7 {
+        .global & {
+            background-color: #FFF;
+            ::after {
+                content: \\"\\";
+                display: block;
+            }
+        }
+    }
+}
+
+[dir=\\"rtl\\"] .test6 {
+    .global & {
+        padding: 5px 10px 5px 5px;
+        border-left-color: #666;
+        div {
+            padding-left: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            ::after {
+                text-align: left;
+            }
+        }
+    }
+}
+
+[dir=\\"ltr\\"] .test6 {
+    .global & {
+        padding: 5px 5px 5px 10px;
+        border-right-color: #666;
+        div {
+            padding-right: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            ::after {
+                text-align: right;
+            }
+        }
+    }
+}"
+`;

--- a/tests/__snapshots__/override-nested-rules.test.ts.snap
+++ b/tests/__snapshots__/override-nested-rules.test.ts.snap
@@ -1,0 +1,181 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Override Tests Nested rules Override {source: ltr} 1`] = `
+".test1 {
+    color: red;
+    left: 10px;
+    .test2 {
+        text-align: left;
+        padding: 5px;
+        width: 100%;
+    }
+}
+
+[dir=\\"rtl\\"] .test1 {
+    left: auto;
+    right: 10px;
+    .test2 {
+        text-align: right;
+    }
+}
+
+.test3 {
+    left: 10px;
+    &.test4 {
+        color: black;
+        margin-left: 20px;
+    }
+    &.test5 {
+        padding: 5px;
+        span {
+            text-align: left;
+        }
+    }
+}
+
+[dir=\\"rtl\\"] .test3 {
+    left: auto;
+    right: 10px;
+    &.test4 {
+        margin-left: 0;
+        margin-right: 20px;
+    }
+    &.test5 {
+        span {
+            text-align: right;
+        }
+    }
+}
+
+.test6 {
+    display: flex;
+    .global & {
+        color: white;
+        padding: 5px 10px 5px 5px;
+        border-left-color: #666;
+        div {
+            margin: 0 auto;
+            padding-left: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            background-color: #FFF;
+            ::after {
+                content: \\"\\";
+                display: block;
+                text-align: left;
+            }
+        }
+    }
+}
+
+[dir=\\"rtl\\"] .test6 {
+    .global & {
+        padding: 5px 5px 5px 10px;
+        border-left-color: currentcolor;
+        border-right-color: #666;
+        div {
+            padding-left: 0;
+            padding-right: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            ::after {
+                text-align: right;
+            }
+        }
+    }
+}"
+`;
+
+exports[`Override Tests Nested rules Override {source: rtl} 1`] = `
+".test1 {
+    color: red;
+    left: 10px;
+    .test2 {
+        text-align: left;
+        padding: 5px;
+        width: 100%;
+    }
+}
+
+[dir=\\"ltr\\"] .test1 {
+    left: auto;
+    right: 10px;
+    .test2 {
+        text-align: right;
+    }
+}
+
+.test3 {
+    left: 10px;
+    &.test4 {
+        color: black;
+        margin-left: 20px;
+    }
+    &.test5 {
+        padding: 5px;
+        span {
+            text-align: left;
+        }
+    }
+}
+
+[dir=\\"ltr\\"] .test3 {
+    left: auto;
+    right: 10px;
+    &.test4 {
+        margin-left: 0;
+        margin-right: 20px;
+    }
+    &.test5 {
+        span {
+            text-align: right;
+        }
+    }
+}
+
+.test6 {
+    display: flex;
+    .global & {
+        color: white;
+        padding: 5px 10px 5px 5px;
+        border-left-color: #666;
+        div {
+            margin: 0 auto;
+            padding-left: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            background-color: #FFF;
+            ::after {
+                content: \\"\\";
+                display: block;
+                text-align: left;
+            }
+        }
+    }
+}
+
+[dir=\\"ltr\\"] .test6 {
+    .global & {
+        padding: 5px 5px 5px 10px;
+        border-left-color: currentcolor;
+        border-right-color: #666;
+        div {
+            padding-left: 0;
+            padding-right: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            ::after {
+                text-align: right;
+            }
+        }
+    }
+}"
+`;

--- a/tests/combined-nested-rules.test.ts
+++ b/tests/combined-nested-rules.test.ts
@@ -1,0 +1,30 @@
+import postcss from 'postcss';
+import postcssRTLCSS from '../src';
+import { PluginOptions, Mode, Source } from '../src/@types';
+import { readCSSFile } from './test-utils';
+
+const baseOptions: PluginOptions = {mode: Mode.combined};
+
+describe('Combined Tests Nested rules', (): void => {
+
+  let input = '';
+
+  beforeEach(async (): Promise<void> => {
+    input = input || await readCSSFile('input-nested.scss');
+  });
+
+  it('Combined {source: rtl}', (): void => {
+    const options: PluginOptions = { ...baseOptions, source: Source.rtl };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('Combined {source: ltr}', (): void => {
+    const options: PluginOptions = { ...baseOptions, source: Source.ltr };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+});

--- a/tests/css/input-nested.scss
+++ b/tests/css/input-nested.scss
@@ -1,0 +1,46 @@
+.test1 {
+    color: red;
+    left: 10px;
+    .test2 {
+        text-align: left;
+        padding: 5px;
+        width: 100%;
+    }
+}
+
+.test3 {
+    left: 10px;
+    &.test4 {
+        color: black;
+        margin-left: 20px;
+    }
+    &.test5 {
+        padding: 5px;
+        span {
+            text-align: left;
+        }
+    }
+}
+
+.test6 {
+    display: flex;
+    .global & {
+        color: white;
+        padding: 5px 10px 5px 5px;
+        border-left-color: #666;
+        div {
+            margin: 0 auto;
+            padding-left: 20px;
+        }
+    }
+    .test7 {
+        .global & {
+            background-color: #FFF;
+            ::after {
+                content: "";
+                display: block;
+                text-align: left;
+            }
+        }
+    }
+}

--- a/tests/override-nested-rules.test.ts
+++ b/tests/override-nested-rules.test.ts
@@ -1,0 +1,30 @@
+import postcss from 'postcss';
+import postcssRTLCSS from '../src';
+import { PluginOptions, Mode, Source } from '../src/@types';
+import { readCSSFile } from './test-utils';
+
+const baseOptions: PluginOptions = {mode: Mode.override};
+
+describe('Override Tests Nested rules', (): void => {
+
+  let input = '';
+
+  beforeEach(async (): Promise<void> => {
+    input = input || await readCSSFile('input-nested.scss');
+  });
+
+  it('Override {source: rtl}', (): void => {
+    const options: PluginOptions = { ...baseOptions, source: Source.rtl };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('Override {source: ltr}', (): void => {
+    const options: PluginOptions = { ...baseOptions, source: Source.ltr };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+});


### PR DESCRIPTION
This merge request adds support for nested rules:

### Input

```scss
.selector-1 {
    left: 10px;
    &.selector-2 {
        color: black;
        margin-left: 20px;
    }
    &.selector-3 {
        padding: 5px;
        span {
            text-align: left;
        }
    }
}
```

### Output combined mode

```scss
.selector-1 {
    &.selector-2 {
        color: black;
    }
    &.selector-3 {
        padding: 5px
    }
}

[dir="ltr"] .selector-1 {
    left: 10px;
    &.selector-2 {
        margin-left: 20px;
    }
    &.selector-3 {
        span {
            text-align: left;
        }
    }
}

[dir="rtl"] .selector-1 {
    right: 10px;
    &.selector-2 {
        margin-right: 20px;
    }
    &.selector-3 {
        span {
            text-align: right;
        }
    }
}
```

### Output override mode

```scss
.selector-1 {
    left: 10px;
    &.selector-2 {
        color: black;
        margin-left: 20px;
    }
    &.selector-3 {
        padding: 5px;
        span {
            text-align: left;
        }
    }
}

[dir="rtl"] .selector-1 {
    left: auto;
    right: 10px;
    &.selector-2 {
        margin-left: 0;
        margin-right: 20px;
    }
    &.selector-3 {
        span {
            text-align: right;
        }
    }
}
```