### PR TITLE
Fix multiple declarations overriding order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.3.1 / 1.6.8] - 2021-05-03
+
+- Fix multiple declarations overriding order
+
 ## [3.3.0 / 1.6.7] - 2021-03-14
 
 - Implemented `/*rtl:source:{source}*/`, `/*rtl:begin:source:{source}*/`, and `/*rtl:end:source*/`

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint src/**/*.ts",
     "copy": "cp -r ./dist/. ./",
     "build": "webpack && tscpaths -p tsconfig.json -s ./src -o ./dist && yarn copy",
-    "prepare": "yarn build && yarn copy",
-    "prepublishOnly": "npm run lint && npm run test",
+    
+    
     "version": "git add .",
     "postversion": "git push && git push --tags"
   },

--- a/src/parsers/declarations.ts
+++ b/src/parsers/declarations.ts
@@ -146,9 +146,11 @@ export const parseDeclarations = (
             const declFlippedProp = declFlipped.prop.trim();
             const declFlippedValue = declFlipped.value.trim();
             const overridenBy = declarations[declPropUnprefixed];
-            const hasBeenOverriden = overridenBy
-                ? overridenBy.some((d: string): boolean => declarationsProps.indexOf(d) >= 0)
-                : false;
+            const hasBeenOverriden = declarationsProps.includes(declPropUnprefixed) || (
+                overridenBy
+                    ? overridenBy.some((d: string): boolean => declarationsProps.indexOf(d) >= 0)
+                    : false
+            );
             const isConflictedDeclaration = safeBothPrefix
                 ? !!allDeclarations[declPropUnprefixed]
                 : false;

--- a/src/utilities/declarations.ts
+++ b/src/utilities/declarations.ts
@@ -50,7 +50,6 @@ const appendDeclarationToRule = (decl: Declaration, rule: Rule): void => {
 };
 
 const hasIgnoreDirectiveInRaws = (decl: Declaration): boolean => {
-    // @ts-ignore
     const raws = !!decl.raws && !!decl.raws.value && decl.raws.value.raw;
     if (raws && RTL_COMMENT_IGNORE_REGEXP.test(raws)) {
         return true;

--- a/tests/__snapshots__/combined-autorename.test.ts.snap
+++ b/tests/__snapshots__/combined-autorename.test.ts.snap
@@ -23,6 +23,22 @@ exports[`Combined Tests Autorename Combined Autorename: flexible 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -584,6 +600,22 @@ exports[`Combined Tests Autorename Combined Autorename: flexible with custom str
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1149,6 +1181,22 @@ exports[`Combined Tests Autorename Combined Autorename: flexible, greedy: true 1
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -1710,6 +1758,22 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives 
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -2275,6 +2339,22 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives,
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -2838,6 +2918,22 @@ exports[`Combined Tests Autorename Combined Autorename: strict 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -3399,6 +3495,22 @@ exports[`Combined Tests Autorename Combined Autorename: strict, greedy: true 1`]
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/combined-basic-options.test.ts.snap
+++ b/tests/__snapshots__/combined-basic-options.test.ts.snap
@@ -23,6 +23,22 @@ exports[`Combined Tests Basic Options Combined {processKeyFrames: true} 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -652,6 +668,22 @@ exports[`Combined Tests Basic Options Combined {processUrls: true} 1`] = `
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -1213,6 +1245,22 @@ exports[`Combined Tests Basic Options Combined {source: rtl, processKeyFrames: t
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1840,6 +1888,22 @@ exports[`Combined Tests Basic Options Combined {source: rtl} 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -2404,6 +2468,22 @@ exports[`Combined Tests Basic Options Combined {useCalc: true} 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -2966,6 +3046,22 @@ exports[`Combined Tests Basic Options Combined Basic 1`] = `
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/combined-prefixes.test.ts.snap
+++ b/tests/__snapshots__/combined-prefixes.test.ts.snap
@@ -23,6 +23,22 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+.ltr .test2 {
+    text-align: left;
+}
+
+.rtl .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -584,6 +600,22 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix propert
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+.ltr .test2, .left-to-right .test2 {
+    text-align: left;
+}
+
+.rtl .test2, .right-to-left .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1161,6 +1193,22 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix, rtlPrefix, and bothP
 .ltr .test1, .left-to-right .test1, .rtl .test1, .right-to-left .test1, .ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     background-color: #FFF;
     background-position: 10px 20px;
+}
+
+.test2 {
+    color: red;
+}
+
+.ltr .test2, .left-to-right .test2 {
+    text-align: left;
+}
+
+.rtl .test2, .right-to-left .test2 {
+    text-align: right;
+}
+
+.ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/combined-safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/combined-safe-prefix.test.ts.snap
@@ -26,6 +26,22 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} 1`
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 [dir] .test3 {
     margin: 1px 2px 3px;
@@ -610,6 +626,22 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} an
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1258,6 +1290,22 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} an
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 [dir] .test3 {
     margin: 1px 2px 3px;
@@ -1842,6 +1890,22 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} an
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/combined-string-map.test.ts.snap
+++ b/tests/__snapshots__/combined-string-map.test.ts.snap
@@ -27,6 +27,22 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -592,6 +608,22 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
     background-position: 10px 20px;
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1161,6 +1193,22 @@ exports[`Combined Tests String Map Combined custom string map and processUrls: t
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     margin: 1px 2px 3px;
@@ -1726,6 +1774,22 @@ exports[`Combined Tests String Map Combined custom string map without names and 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
     background-position: 10px 20px;
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/override-autorename.test.ts.snap
+++ b/tests/__snapshots__/override-autorename.test.ts.snap
@@ -21,6 +21,19 @@ exports[`Override Tests Autorename Override Autorename: flexible 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -535,6 +548,19 @@ exports[`Override Tests Autorename Override Autorename: flexible with custom str
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1053,6 +1079,19 @@ exports[`Override Tests Autorename Override Autorename: flexible, greedy: true 1
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -1567,6 +1606,19 @@ exports[`Override Tests Autorename Override Autorename: only control directives 
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -2085,6 +2137,19 @@ exports[`Override Tests Autorename Override Autorename: only control directives,
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -2601,6 +2666,19 @@ exports[`Override Tests Autorename Override Autorename: strict 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -3115,6 +3193,19 @@ exports[`Override Tests Autorename Override Autorename: strict, greedy: true 1`]
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/override-basic-options.test.ts.snap
+++ b/tests/__snapshots__/override-basic-options.test.ts.snap
@@ -21,6 +21,19 @@ exports[`Override Tests Basic Options Override {processKeyFrames: true} 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -597,6 +610,19 @@ exports[`Override Tests Basic Options Override {processUrls: true} 1`] = `
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -1111,6 +1137,19 @@ exports[`Override Tests Basic Options Override {source: rtl, processKeyFrames: t
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1679,6 +1718,19 @@ exports[`Override Tests Basic Options Override {source: rtl} 1`] = `
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -2188,6 +2240,19 @@ exports[`Override Tests Basic Options Override {useCalc: true} 1`] = `
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -2705,6 +2770,19 @@ exports[`Override Tests Basic Options Override Basic 1`] = `
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/override-prefixes.test.ts.snap
+++ b/tests/__snapshots__/override-prefixes.test.ts.snap
@@ -21,6 +21,19 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+.rtl .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -535,6 +548,19 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+.rtl .test2, .right-to-left .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1060,6 +1086,19 @@ exports[`Override Tests Prefixes Override custom ltrPrefix, rtlPrefix, and bothP
 .ltr .test1, .left-to-right .test1, .rtl .test1, .right-to-left .test1, .ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     background-color: #FFF;
     background-position: 10px 20px;
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+.rtl .test2, .right-to-left .test2 {
+    text-align: right;
+}
+
+.ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/override-safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/override-safe-prefix.test.ts.snap
@@ -24,6 +24,22 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} 1`
     transform: translate(50%, 50%);
 }
 
+.test2 {
+    color: red;
+}
+
+[dir] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 [dir] .test3 {
     direction: ltr;
@@ -595,6 +611,22 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} an
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1230,6 +1262,22 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} an
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+}
+
+[dir] .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 [dir] .test3 {
     direction: ltr;
@@ -1801,6 +1849,22 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} an
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir] .test2 {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/__snapshots__/override-string-map.test.ts.snap
+++ b/tests/__snapshots__/override-string-map.test.ts.snap
@@ -25,6 +25,19 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -543,6 +556,19 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
     background-position: 10px 20px;
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */
@@ -1065,6 +1091,19 @@ exports[`Override Tests String Map Override custom string map and processUrls: t
     background-position: 10px 20px;
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;
@@ -1583,6 +1622,19 @@ exports[`Override Tests String Map Override custom string map without names and 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
     background-position: 10px 20px;
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test2 {
+    text-align: right;
+}
+
+[dir] .test2 {
+    text-align: center;
 }
 
 /* Comment not related to rtl */

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -10,6 +10,12 @@
     width: 100%;
 }
 
+.test2 {
+    color: red;
+    text-align: left;
+    text-align: center;
+}
+
 /* Comment not related to rtl */
 .test3 {
     direction: ltr;


### PR DESCRIPTION
This pull request fixes a bug when the same declaration property is declared multiple times in a rule.

### Input

```css
.test {
    color: red;
    text-align: left;
    text-align: center;
}
```

### Output Before

```css
.test {
    color: red;
    text-align: center;
}

[dir="ltr"] .test {
    text-align: left;
}

[dir="rtl"] .test {
    text-align: right;
}
```

> In the original CSS file the `text-align: center` is overriding the `text-align: left` but in the output, the opposite occurs due to a higher specificity of the `[dir="ltr"]` and `[dir="rtl"]` rules.

### Output After the Fix

```css
.test {
    color: red;
}

[dir="ltr"] .test {
    text-align: left;
}

[dir="rtl"] .test {
    text-align: right;
}

[dir] .test {
    text-align: center;
}
```

> The `bothPrefix` property has been used to create a rule and maintain the same input behavior.
