### PR TITLE
Fix a bug with :root and html rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.3.2 / 1.6.9] - 2021-05-12
+
+- Fix a bug with :root and html rules
+
 ## [3.3.1 / 1.6.8] - 2021-05-03
 
 - Fix multiple declarations overriding order

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,6 +11,8 @@ export const RTL_COMMENT_REGEXP = /rtl:/;
 export const RTL_COMMENT_IGNORE_REGEXP = /rtl:ignore/;
 export const RTL_CONTROL_DIRECTIVE_REG_EXP = /^\/\*!? *rtl:?(begin|end)?:(\w+):?([^*]*?) *\*\/$/;
 export const FLIP_PROPERTY_REGEXP = /(right|left)/i;
+export const HTML_SELECTOR_REGEXP = /^(html)(?=\W|$)/;
+export const ROOT_SELECTOR_REGEXP = /(:root)(?=\W|$)/;
 
 export enum CONTROL_DIRECTIVE {
     IGNORE = 'ignore',

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -1,12 +1,23 @@
 import { Rule } from 'postcss';
 import { strings, Mode, Source } from '@types';
+import { HTML_SELECTOR_REGEXP, ROOT_SELECTOR_REGEXP } from '@constants';
 import { store } from '@data/store';
+
+const addPrefix = (prefix: string, selector: string): string => {
+    if (HTML_SELECTOR_REGEXP.test(selector)) {
+        return selector.replace(HTML_SELECTOR_REGEXP, `$1${prefix}`);
+    }
+    if (ROOT_SELECTOR_REGEXP.test(selector)) {
+        return selector.replace(ROOT_SELECTOR_REGEXP, `${prefix}$1`);
+    }
+    return `${prefix} ${selector}`;
+};
 
 export const addSelectorPrefixes = (rule: Rule, prefixes: strings): void => {
     rule.selectors = typeof prefixes === 'string'
-        ? rule.selectors.map((selector: string): string => `${prefixes} ${selector}`)
+        ? rule.selectors.map((selector: string): string => addPrefix(prefixes, selector))
         : rule.selectors.reduce((selectors: string[], selector: string): string[] => {
-            selectors = selectors.concat(prefixes.map((prefix: string): string => `${prefix} ${selector}`));
+            selectors = selectors.concat(prefixes.map((prefix: string): string => addPrefix(prefix, selector)));
             return selectors;
         }, []);
 };

--- a/tests/__snapshots__/combined-autorename.test.ts.snap
+++ b/tests/__snapshots__/combined-autorename.test.ts.snap
@@ -576,6 +576,26 @@ exports[`Combined Tests Autorename Combined Autorename: flexible 1`] = `
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1155,6 +1175,26 @@ exports[`Combined Tests Autorename Combined Autorename: flexible with custom str
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1734,6 +1774,26 @@ exports[`Combined Tests Autorename Combined Autorename: flexible, greedy: true 1
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -2313,6 +2373,26 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives 
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -2892,6 +2972,26 @@ exports[`Combined Tests Autorename Combined Autorename: only control directives,
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -3471,6 +3571,26 @@ exports[`Combined Tests Autorename Combined Autorename: strict 1`] = `
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -4050,5 +4170,25 @@ exports[`Combined Tests Autorename Combined Autorename: strict, greedy: true 1`]
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/combined-basic-options.test.ts.snap
+++ b/tests/__snapshots__/combined-basic-options.test.ts.snap
@@ -638,6 +638,26 @@ exports[`Combined Tests Basic Options Combined {processKeyFrames: true} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1221,6 +1241,26 @@ exports[`Combined Tests Basic Options Combined {processUrls: true} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1862,6 +1902,26 @@ exports[`Combined Tests Basic Options Combined {source: rtl, processKeyFrames: t
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -2441,6 +2501,26 @@ exports[`Combined Tests Basic Options Combined {source: rtl} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -3022,6 +3102,26 @@ exports[`Combined Tests Basic Options Combined {useCalc: true} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -3601,5 +3701,25 @@ exports[`Combined Tests Basic Options Combined Basic 1`] = `
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/combined-prefixes.test.ts.snap
+++ b/tests/__snapshots__/combined-prefixes.test.ts.snap
@@ -576,6 +576,26 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix 1`] = `
     .test49 {
         color: white;
     }
+}
+
+.ltr:root {
+    text-align: right;
+}
+
+.rtl:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html.ltr .test50 {
+    left: 10px;
+}
+
+html.rtl .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1165,6 +1185,26 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix and rtlPrefix propert
     .test49 {
         color: white;
     }
+}
+
+.ltr:root, .left-to-right:root {
+    text-align: right;
+}
+
+.rtl:root, .right-to-left:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html.ltr .test50, html.left-to-right .test50 {
+    left: 10px;
+}
+
+html.rtl .test50, html.right-to-left .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1758,5 +1798,25 @@ exports[`Combined Tests Prefixes Combined custom ltrPrefix, rtlPrefix, and bothP
     .test49 {
         color: white;
     }
+}
+
+.ltr:root, .left-to-right:root {
+    text-align: right;
+}
+
+.rtl:root, .right-to-left:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html.ltr .test50, html.left-to-right .test50 {
+    left: 10px;
+}
+
+html.rtl .test50, html.right-to-left .test50 {
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/combined-safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/combined-safe-prefix.test.ts.snap
@@ -599,6 +599,26 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} 1`
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1260,6 +1280,26 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} an
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1863,6 +1903,26 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} an
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -2465,5 +2525,25 @@ exports[`Combined Tests safeBothPrefix Option Combined {safeBothPrefix: true} an
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/combined-string-map.test.ts.snap
+++ b/tests/__snapshots__/combined-string-map.test.ts.snap
@@ -580,6 +580,26 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1163,6 +1183,26 @@ exports[`Combined Tests String Map Combined custom no-valid string map and proce
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -1746,6 +1786,26 @@ exports[`Combined Tests String Map Combined custom string map and processUrls: t
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;
 
@@ -2329,5 +2389,25 @@ exports[`Combined Tests String Map Combined custom string map without names and 
     .test49 {
         color: white;
     }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/override-autorename.test.ts.snap
+++ b/tests/__snapshots__/override-autorename.test.ts.snap
@@ -526,6 +526,24 @@ exports[`Override Tests Autorename Override Autorename: flexible 1`] = `
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1055,6 +1073,24 @@ exports[`Override Tests Autorename Override Autorename: flexible with custom str
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1584,6 +1620,24 @@ exports[`Override Tests Autorename Override Autorename: flexible, greedy: true 1
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -2113,6 +2167,24 @@ exports[`Override Tests Autorename Override Autorename: only control directives 
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -2642,6 +2714,24 @@ exports[`Override Tests Autorename Override Autorename: only control directives,
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -3171,6 +3261,24 @@ exports[`Override Tests Autorename Override Autorename: strict 1`] = `
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -3700,5 +3808,23 @@ exports[`Override Tests Autorename Override Autorename: strict, greedy: true 1`]
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/override-basic-options.test.ts.snap
+++ b/tests/__snapshots__/override-basic-options.test.ts.snap
@@ -582,6 +582,24 @@ exports[`Override Tests Basic Options Override {processKeyFrames: true} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1115,6 +1133,24 @@ exports[`Override Tests Basic Options Override {processUrls: true} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1694,6 +1730,24 @@ exports[`Override Tests Basic Options Override {source: rtl, processKeyFrames: t
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -2217,6 +2271,24 @@ exports[`Override Tests Basic Options Override {source: rtl} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -2748,6 +2820,24 @@ exports[`Override Tests Basic Options Override {useCalc: true} 1`] = `
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -3277,5 +3367,23 @@ exports[`Override Tests Basic Options Override Basic 1`] = `
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/override-prefixes.test.ts.snap
+++ b/tests/__snapshots__/override-prefixes.test.ts.snap
@@ -526,6 +526,24 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+.ltr:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html.rtl .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1060,6 +1078,24 @@ exports[`Override Tests Prefixes Override custom ltrPrefix and rtlPrefix propert
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+.ltr:root, .left-to-right:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html.rtl .test50, html.right-to-left .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1598,5 +1634,23 @@ exports[`Override Tests Prefixes Override custom ltrPrefix, rtlPrefix, and bothP
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+.ltr:root, .left-to-right:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html.rtl .test50, html.right-to-left .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/override-safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/override-safe-prefix.test.ts.snap
@@ -586,6 +586,27 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} 1`
     .test49 {
         color: white;
     }
+}
+
+[dir]:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1231,6 +1252,27 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} an
     .test49 {
         color: white;
     }
+}
+
+[dir]:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1824,6 +1866,27 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} an
     .test49 {
         color: white;
     }
+}
+
+[dir]:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -2407,5 +2470,26 @@ exports[`Override Tests safeBothPrefix Option Override {safeBothPrefix: true} an
     .test49 {
         color: white;
     }
+}
+
+[dir]:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;

--- a/tests/__snapshots__/override-string-map.test.ts.snap
+++ b/tests/__snapshots__/override-string-map.test.ts.snap
@@ -530,6 +530,24 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1063,6 +1081,24 @@ exports[`Override Tests String Map Override custom no-valid string map and proce
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -1596,6 +1632,24 @@ exports[`Override Tests String Map Override custom string map and processUrls: t
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;
 
@@ -2129,5 +2183,23 @@ exports[`Override Tests String Map Override custom string map without names and 
     .test49 {
         color: white;
     }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
 }"
 `;

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -415,3 +415,12 @@
         color: white;
     }
 }
+
+:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}


### PR DESCRIPTION
For rules containing `:root` and `html` the output was wrong:

### Input

```css
:root {
    text-align: left;
}

html .test50 {
    color: red;
    left: 10px;
}
```

### Wrong output before the fix

```css
[dir="ltr"] :root {
    text-align: left;
}

[dir="rtl"] :root {
    text-align: right;
}

html .test50 {
    color: red;
}

[dir="ltr"] html .test50 {
    left: 10px;
}

[dir="rtl"] html .test50 {
    right: 10px;
}
```

### Right output after the fix

```css
[dir="ltr"]:root {
    text-align: left;
}

[dir="rtl"]:root {
    text-align: right;
}

html .test50 {
    color: red;
}

html[dir="ltr"] .test50 {
    left: 10px;
}

html[dir="rtl"] .test50 {
    right: 10px;
}
```