### PR TITLE
Add a new option to ignore rules already prefixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.3.3 / 1.7.0] - 2021-05-23
+
+- Added a new option to ignore rules already prefixed
+
 ## [3.3.2 / 1.6.9] - 2021-05-12
 
 - Fix a bug with :root and html rules

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ All the options are optional, and a default value will be used if any of them is
 | rtlPrefix          | `string` or `string[]`    | `[dir="rtl"]`   | Prefix to use in the right-to-left CSS rules                 |
 | bothPrefix         | `string` or `string[]`    | `[dir]`         | Prefix to create a new rule that affects both directions when the specificity of the ltr or rtl rules will override its declarations |
 | safeBothPrefix     | `boolean`                 | `false`         | Add the `bothPrefix` to those declarations that can be affected by the direction to avoid them being overridden by specificity |
+| ignorePrefixedRules| `boolean`                 | true            | Ignores rules that have been prefixed with some of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix` |
 | source             | `Source (string)`         | `Source.ltr`    | The direction from which the final CSS will be generated     |
 | processUrls        | `boolean`                 | `false`         | Change the strings in URLs using the string map         |
 | processKeyFrames   | `boolean`                 | `false`         | Flip keyframe animations                                     |
@@ -585,6 +586,75 @@ The result is that the `padding` properties of `test1` have more specificity tha
 ```
 
 As `test2` has the same level of specificity as `test1`, now the result is that the `padding` is reset if both rules are used at the same time.
+
+</p>
+
+</details>
+
+---
+
+#### ignorePrefixedRules
+
+<details><summary>Expand</summary>
+<p>
+
+This option is to ignore the rules that have been prefixed with one of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix`:
+
+##### input
+
+```css
+[dir="ltr"] test {
+    left: 10px;
+}
+
+[dir="rtl"] test {
+    right: 10px;
+}
+```
+
+##### ignorePrefixedRules true
+
+```javascript
+const options = { ignorePrefixedRules: true }; // This is the default value
+```
+
+##### output
+
+```css
+[dir="ltr"] test {
+    left: 10px;
+}
+
+[dir="rtl"] test {
+    right: 10px;
+}
+```
+
+##### ignorePrefixedRules false
+
+```javascript
+const options = { ignorePrefixedRules: false };
+```
+
+##### output
+
+```css
+[dir="ltr"] [dir="ltr"] test {
+    left: 10px;
+}
+
+[dir="rtl"] [dir="ltr"] test {
+    right: 10px;
+}
+
+[dir="ltr"] [dir="rtl"] test {
+    right: 10px;
+}
+
+[dir="rtl"] [dir="rtl"] test {
+    left: 10px;
+}
+```
 
 </p>
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -47,6 +47,7 @@ export interface PluginOptions {
     rtlPrefix?: strings;
     bothPrefix?: strings;
     safeBothPrefix?: boolean;
+    ignorePrefixedRules?: boolean;
     source?: SourceValues;
     processUrls?: boolean;
     processKeyFrames?: boolean;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,6 +13,8 @@ export const RTL_CONTROL_DIRECTIVE_REG_EXP = /^\/\*!? *rtl:?(begin|end)?:(\w+):?
 export const FLIP_PROPERTY_REGEXP = /(right|left)/i;
 export const HTML_SELECTOR_REGEXP = /^(html)(?=\W|$)/;
 export const ROOT_SELECTOR_REGEXP = /(:root)(?=\W|$)/;
+export const REG_EXP_CHARACTERS_REG_EXP = /[.?*+^$[\]\\(){}|-]/g;
+export const LAST_WORD_CHARACTER_REG_EXP = /\w$/;
 
 export enum CONTROL_DIRECTIVE {
     IGNORE = 'ignore',

--- a/src/parsers/rules.ts
+++ b/src/parsers/rules.ts
@@ -9,7 +9,7 @@ import {
 } from '@utilities/directives';
 import { walkContainer } from '@utilities/containers';
 import { cleanRuleRawsBefore } from '@utilities/rules';
-import { addSelectorPrefixes } from '@utilities/selectors';
+import { addSelectorPrefixes, hasSelectorsPrefixed } from '@utilities/selectors';
 import { parseDeclarations } from './declarations';
 
 export const parseRules = (
@@ -77,19 +77,23 @@ export const parseRules = (
             );
 
             if (checkDirective(controlDirectives, CONTROL_DIRECTIVE.RENAME)) {
-                store.rulesAutoRename.push(rule);
-                parseDeclarations(
-                    rule,
-                    hasParentRule,
-                    sourceDirectiveValue,
-                    true
-                );
+                if (!hasSelectorsPrefixed(rule)) {
+                    store.rulesAutoRename.push(rule);
+                    parseDeclarations(
+                        rule,
+                        hasParentRule,
+                        sourceDirectiveValue,
+                        true
+                    );
+                }                
             } else {
-                parseDeclarations(
-                    rule,
-                    hasParentRule,
-                    sourceDirectiveValue
-                );
+                if (!hasSelectorsPrefixed(rule)) {
+                    parseDeclarations(
+                        rule,
+                        hasParentRule,
+                        sourceDirectiveValue
+                    );
+                }                
             }
             
             parseRules(

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -15,11 +15,27 @@ const addPrefix = (prefix: string, selector: string): string => {
 
 export const addSelectorPrefixes = (rule: Rule, prefixes: strings): void => {
     rule.selectors = typeof prefixes === 'string'
-        ? rule.selectors.map((selector: string): string => addPrefix(prefixes, selector))
+        ? rule.selectors.map((selector: string): string => {
+            if (store.rulesPrefixRegExp.test(selector)) {
+                return selector;
+            }
+            return addPrefix(prefixes, selector);
+        })
         : rule.selectors.reduce((selectors: string[], selector: string): string[] => {
-            selectors = selectors.concat(prefixes.map((prefix: string): string => addPrefix(prefix, selector)));
+            if (store.rulesPrefixRegExp.test(selector)) {
+                selectors = [...selectors, selector];
+            } else {
+                selectors = selectors.concat(
+                    prefixes.map((prefix: string): string => addPrefix(prefix, selector))
+                );
+            }
             return selectors;
         }, []);
+};
+
+export const hasSelectorsPrefixed = (rule: Rule): boolean => {
+    const prefixed = rule.selectors.find((selector: string) => store.rulesPrefixRegExp.test(selector));
+    return !!prefixed;
 };
 
 export const addProperSelectorPrefixes = (

--- a/tests/__snapshots__/combined-prefixed.test.ts.snap
+++ b/tests/__snapshots__/combined-prefixed.test.ts.snap
@@ -1,0 +1,337 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Prefixed Tests Custom prefixes 1`] = `
+".test {
+    color: red;
+}
+
+.rtl .test {
+    left: 10px;
+}
+
+.ltr .test {
+    right: 10px;
+}
+
+.ltr .rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+.rtl .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+.ltr .ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+.rtl .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+.ltr [dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+.rtl [dir=\\"ltr\\"] .test3 {
+    text-align: right;
+}
+
+.ltr [dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+.rtl [dir=\\"rtl\\"] .test3 {
+    text-align: left;
+}
+
+.ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl [dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+.rtl .test6 {
+    left: 5px;
+}
+
+.ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+.rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.ltr [dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+.rtl [dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+.ltr [dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+.rtl [dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}"
+`;
+
+exports[`Prefixed Tests Prefixed default 1`] = `
+".test {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .rtl .test {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .rtl .test {
+    right: 10px;
+}
+
+[dir=\\"ltr\\"] .ltr .test {
+    right: 10px;
+}
+
+[dir=\\"rtl\\"] .ltr .test {
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] .ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+[dir=\\"rtl\\"] .test6 {
+    left: 5px;
+}
+
+[dir=\\"ltr\\"] .ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"rtl\\"] .ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"ltr\\"] .rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"rtl\\"] .rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+[dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}"
+`;
+
+exports[`Prefixed Tests Prefixed with array 1`] = `
+".test {
+    color: red;
+}
+
+.rtl .test {
+    left: 10px;
+}
+
+.ltr .test {
+    right: 10px;
+}
+
+.ltr .rtlignore .test2, [dir=\\"ltr\\"] .rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+.rtl .rtlignore .test2, [dir=\\"rtl\\"] .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+.ltr .ltrignore .test2, [dir=\\"ltr\\"] .ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+.rtl .ltrignore .test2, [dir=\\"rtl\\"] .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+.ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+.rtl .test6, [dir=\\"rtl\\"] .test6 {
+    left: 5px;
+}
+
+.ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+.rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+[dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}"
+`;
+
+exports[`Prefixed Tests ignorePrefixedRules false 1`] = `
+".test {
+    color: red;
+}
+
+[dir=\\"ltr\\"] .rtl .test {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .rtl .test {
+    right: 10px;
+}
+
+[dir=\\"ltr\\"] .ltr .test {
+    right: 10px;
+}
+
+[dir=\\"rtl\\"] .ltr .test {
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] .rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] [dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test3 {
+    text-align: right;
+}
+
+[dir=\\"ltr\\"] [dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+[dir=\\"rtl\\"] .test6 {
+    left: 5px;
+}
+
+[dir=\\"ltr\\"] .ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"rtl\\"] .ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"ltr\\"] .rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"rtl\\"] .rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"ltr\\"] [dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+[dir=\\"ltr\\"] [dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}"
+`;

--- a/tests/__snapshots__/override-prefixed.test.ts.snap
+++ b/tests/__snapshots__/override-prefixed.test.ts.snap
@@ -1,0 +1,341 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Prefixed Tests Custom prefixes 1`] = `
+".test {
+    color: red;
+}
+
+.rtl .test {
+    left: 10px;
+}
+
+.ltr .test {
+    right: 10px;
+}
+
+.rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+.rtl .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+.ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+.rtl .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+.rtl [dir=\\"ltr\\"] .test3 {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+.rtl [dir=\\"rtl\\"] .test3 {
+    text-align: left;
+}
+
+.ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl [dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+.rtl .test6 {
+    left: 5px;
+}
+
+.ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+.rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+.rtl [dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+[dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+.rtl [dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}"
+`;
+
+exports[`Prefixed Tests Prefixed default 1`] = `
+".test {
+    color: red;
+}
+
+.rtl .test {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .rtl .test {
+    left: auto;
+    right: 10px;
+}
+
+.ltr .test {
+    right: 10px;
+}
+
+[dir=\\"rtl\\"] .ltr .test {
+    right: auto;
+    left: 10px;
+}
+
+.rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+.ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] .ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+[dir=\\"rtl\\"] .test6 {
+    left: 5px;
+}
+
+.rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"rtl\\"] .ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"rtl\\"] .rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+[dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}"
+`;
+
+exports[`Prefixed Tests Prefixed with array 1`] = `
+".test {
+    color: red;
+}
+
+.rtl .test {
+    left: 10px;
+}
+
+.ltr .test {
+    right: 10px;
+}
+
+.rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+.rtl .rtlignore .test2, [dir=\\"rtl\\"] .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+.ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+.rtl .ltrignore .test2, [dir=\\"rtl\\"] .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+.ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+.rtl .test6, [dir=\\"rtl\\"] .test6 {
+    left: 5px;
+}
+
+.ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+.rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+[dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}"
+`;
+
+exports[`Prefixed Tests ignorePrefixedRules false 1`] = `
+".test {
+    color: red;
+}
+
+.rtl .test {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] .rtl .test {
+    left: auto;
+    right: 10px;
+}
+
+.ltr .test {
+    right: 10px;
+}
+
+[dir=\\"rtl\\"] .ltr .test {
+    right: auto;
+    left: 10px;
+}
+
+.rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .rtlignore .test2 {
+    padding: 2px 16px 8px 4px;
+}
+
+.ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+[dir=\\"rtl\\"] .ltrignore .test2 {
+    margin: 2px 16px 8px 4px;
+}
+
+[dir=\\"ltr\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test3 {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] .test3 {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test3 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] .ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+[dir=\\"rtl\\"] .test6 {
+    left: 5px;
+}
+
+.rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"rtl\\"] .ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.ltr .test7-ltr {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+[dir=\\"rtl\\"] .rtl .test7-rtl {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}
+
+[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+[dir=\\"ltr\\"] .test8-ltr {
+    background-image: url(\\"/icons/icon-rtl.png\\");
+}
+
+[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test8-rtl {
+    background-image: url(\\"/icons/icon-ltr.png\\");
+}"
+`;

--- a/tests/combined-prefixed.test.ts
+++ b/tests/combined-prefixed.test.ts
@@ -1,0 +1,44 @@
+import postcss from 'postcss';
+import postcssRTLCSS from '../src';
+import { PluginOptions, Mode } from '../src/@types';
+import { readCSSFile } from './test-utils';
+
+const baseOptions: PluginOptions = {mode: Mode.combined, processUrls: true};
+
+describe('Prefixed Tests', (): void => {
+
+  let input = '';
+
+  beforeEach(async (): Promise<void> => {
+    input = input || await readCSSFile('input-prefixed.css');
+  });
+
+  it('Prefixed default', (): void => {
+    const options: PluginOptions = { ...baseOptions };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('Custom prefixes', (): void => {
+    const options: PluginOptions = { ...baseOptions, rtlPrefix: '.rtl', ltrPrefix: '.ltr' };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('Prefixed with array', (): void => {
+    const options: PluginOptions = { ...baseOptions, rtlPrefix: ['.rtl', '[dir="rtl"]'], ltrPrefix: ['.ltr', '[dir="ltr"]'] };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('ignorePrefixedRules false', (): void => {
+    const options: PluginOptions = { ...baseOptions, ignorePrefixedRules: false };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+});

--- a/tests/css/input-prefixed.css
+++ b/tests/css/input-prefixed.css
@@ -1,0 +1,60 @@
+.test {
+    color: red;
+}
+
+.rtl .test {
+    left: 10px;
+}
+
+.ltr .test {
+    right: 10px;
+}
+
+.rtlignore .test2 {
+    padding: 2px 4px 8px 16px;
+}
+
+.ltrignore .test2 {
+    margin: 2px 4px 8px 16px;
+}
+
+[dir="ltr"] .test3 {
+    text-align: left;
+}
+
+[dir="rtl"] .test3 {
+    text-align: right;
+}
+
+/*rtl:raw:.ltr .test4 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir="rtl"] .test5 {
+    transform: translate(10px, 20px);
+}
+
+.test6 {
+    left: 5px;
+}
+*/
+
+/*rtl:begin:rename*/
+.ltr .test7-ltr {
+    background-image: url("/icons/icon-left.png");
+}
+
+.rtl .test7-rtl {
+    background-image: url("/icons/icon-right.png");
+}
+
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-ltr.png");
+}
+
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-rtl.png");
+}
+/*rtl:end:rename*/

--- a/tests/override-prefixed.test.ts
+++ b/tests/override-prefixed.test.ts
@@ -1,0 +1,44 @@
+import postcss from 'postcss';
+import postcssRTLCSS from '../src';
+import { PluginOptions, Mode } from '../src/@types';
+import { readCSSFile } from './test-utils';
+
+const baseOptions: PluginOptions = {mode: Mode.override, processUrls: true};
+
+describe('Prefixed Tests', (): void => {
+
+  let input = '';
+
+  beforeEach(async (): Promise<void> => {
+    input = input || await readCSSFile('input-prefixed.css');
+  });
+
+  it('Prefixed default', (): void => {
+    const options: PluginOptions = { ...baseOptions };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('Custom prefixes', (): void => {
+    const options: PluginOptions = { ...baseOptions, rtlPrefix: '.rtl', ltrPrefix: '.ltr' };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('Prefixed with array', (): void => {
+    const options: PluginOptions = { ...baseOptions, rtlPrefix: ['.rtl', '[dir="rtl"]'], ltrPrefix: ['.ltr', '[dir="ltr"]'] };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+  it('ignorePrefixedRules false', (): void => {
+    const options: PluginOptions = { ...baseOptions, ignorePrefixedRules: false };
+    const output = postcss([postcssRTLCSS(options)]).process(input);
+    expect(output.css).toMatchSnapshot();
+    expect(output.warnings()).toHaveLength(0);
+  });
+
+});


### PR DESCRIPTION
This pull request adds a new option to ignore rules already prefixed:

#### ignorePrefixedRules

##### input

```css
[dir="ltr"] test {
    left: 10px;
}

[dir="rtl"] test {
    right: 10px;
}
```

##### ignorePrefixedRules true

```javascript
const options = { ignorePrefixedRules: true }; // This is the default value
```

##### output

```css
[dir="ltr"] test {
    left: 10px;
}

[dir="rtl"] test {
    right: 10px;
}
```

##### ignorePrefixedRules false

```javascript
const options = { ignorePrefixedRules: false };
```

##### output

```css
[dir="ltr"] [dir="ltr"] test {
    left: 10px;
}

[dir="rtl"] [dir="ltr"] test {
    right: 10px;
}

[dir="ltr"] [dir="rtl"] test {
    right: 10px;
}

[dir="rtl"] [dir="rtl"] test {
    left: 10px;
}
```