### PR TITLE
Add support for nested at-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.3.5] - 2021-08-25
+
+- Support for nested at-rules
+
 ## [3.3.4] - 2021-05-23
 
 - Added a new option to support declarations aliases

--- a/src/parsers/atrules.ts
+++ b/src/parsers/atrules.ts
@@ -1,4 +1,4 @@
-import postcss, { Root, Node, AtRule, Comment } from 'postcss';
+import postcss, { Root, Container, Node, AtRule, Comment } from 'postcss';
 import rtlcss from 'rtlcss';
 import { AtRulesObject, AtRulesStringMap, Source, ControlDirective } from '@types';
 import { AT_RULE_TYPE, RULE_TYPE, KEYFRAMES_NAME, CONTROL_DIRECTIVE } from '@constants';
@@ -25,12 +25,12 @@ export const getKeyFramesStringMap = (keyframes: AtRulesObject[]): AtRulesString
 
 export const getKeyFramesRegExp = (stringMap: AtRulesStringMap): RegExp => new RegExp(`(^|[^\\w-]| )(${ Object.keys(stringMap).join('|') })( |[^\\w-]|$)`, 'g');
 
-export const parseAtRules = (css: Root): void => {
+export const parseAtRules = (container: Container): void => {
 
     const controlDirectives: Record<string, ControlDirective> = {};
 
     walkContainer(
-        css,
+        container,
         [ AT_RULE_TYPE, RULE_TYPE ],
         (_comment: Comment, controlDirective: ControlDirective): void => {
 
@@ -56,6 +56,8 @@ export const parseAtRules = (css: Root): void => {
             const sourceDirectiveValue = getSourceDirectiveValue(controlDirectives);
 
             parseRules(atRule, sourceDirectiveValue);
+
+            parseAtRules(atRule);            
 
         }
     );

--- a/tests/__snapshots__/nested-rules.test.ts.snap
+++ b/tests/__snapshots__/nested-rules.test.ts.snap
@@ -107,6 +107,43 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
             }
         }
     }
+}
+
+@supports (display: contents) and (display: grid) {
+    .test8 {
+        color: red;
+    }
+
+    [dir=\\"ltr\\"] .test8 {
+        left: 10px;
+        text-align: left;
+    }
+
+    [dir=\\"rtl\\"] .test8 {
+        right: 10px;
+        text-align: right;
+    }
+    @media screen and (max-width: 800px) {
+        [dir=\\"ltr\\"] .test9 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"rtl\\"] .test9 {
+            padding: 0 1.7em 0 0.6em;
+        }
+    }
+}
+
+@media screen and (max-width: 800px) {
+    @supports (display: contents) and (display: grid) {
+        [dir=\\"ltr\\"] .test10 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"rtl\\"] .test10 {
+            padding: 0 1.7em 0 0.6em;
+        }
+    }
 }"
 `;
 
@@ -217,6 +254,43 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
             }
         }
     }
+}
+
+@supports (display: contents) and (display: grid) {
+    .test8 {
+        color: red;
+    }
+
+    [dir=\\"rtl\\"] .test8 {
+        left: 10px;
+        text-align: left;
+    }
+
+    [dir=\\"ltr\\"] .test8 {
+        right: 10px;
+        text-align: right;
+    }
+    @media screen and (max-width: 800px) {
+        [dir=\\"rtl\\"] .test9 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"ltr\\"] .test9 {
+            padding: 0 1.7em 0 0.6em;
+        }
+    }
+}
+
+@media screen and (max-width: 800px) {
+    @supports (display: contents) and (display: grid) {
+        [dir=\\"rtl\\"] .test10 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"ltr\\"] .test10 {
+            padding: 0 1.7em 0 0.6em;
+        }
+    }
 }"
 `;
 
@@ -307,6 +381,41 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
             }
         }
     }
+}
+
+@supports (display: contents) and (display: grid) {
+    .test8 {
+        color: red;
+        left: 10px;
+        text-align: left;
+    }
+
+    [dir=\\"rtl\\"] .test8 {
+        left: auto;
+        right: 10px;
+        text-align: right;
+    }
+    @media screen and (max-width: 800px) {
+        .test9 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"rtl\\"] .test9 {
+            padding: 0 1.7em 0 0.6em;
+        }
+    }
+}
+
+@media screen and (max-width: 800px) {
+    @supports (display: contents) and (display: grid) {
+        .test10 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"rtl\\"] .test10 {
+            padding: 0 1.7em 0 0.6em;
+        }
+    }
 }"
 `;
 
@@ -395,6 +504,41 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
             ::after {
                 text-align: right;
             }
+        }
+    }
+}
+
+@supports (display: contents) and (display: grid) {
+    .test8 {
+        color: red;
+        left: 10px;
+        text-align: left;
+    }
+
+    [dir=\\"ltr\\"] .test8 {
+        left: auto;
+        right: 10px;
+        text-align: right;
+    }
+    @media screen and (max-width: 800px) {
+        .test9 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"ltr\\"] .test9 {
+            padding: 0 1.7em 0 0.6em;
+        }
+    }
+}
+
+@media screen and (max-width: 800px) {
+    @supports (display: contents) and (display: grid) {
+        .test10 {
+            padding: 0 0.6em 0 1.7em;
+        }
+
+        [dir=\\"ltr\\"] .test10 {
+            padding: 0 1.7em 0 0.6em;
         }
     }
 }"

--- a/tests/css/input-nested.scss
+++ b/tests/css/input-nested.scss
@@ -44,3 +44,24 @@
         }
     }
 }
+
+@supports (display: contents) and (display: grid) {
+    .test8 {
+        color: red;
+        left: 10px;
+        text-align: left;
+    }
+    @media screen and (max-width: 800px) {
+        .test9 {
+            padding: 0 0.6em 0 1.7em;
+        }
+    }
+}
+
+@media screen and (max-width: 800px) {
+    @supports (display: contents) and (display: grid) {
+        .test10 {
+            padding: 0 0.6em 0 1.7em;
+        }
+    }
+}


### PR DESCRIPTION
Nested rules are now parsed:

#### input

```css
@supports (display: contents) and (display: grid) {
    .test1 {
        color: red;
        left: 10px;
        text-align: left;
    }
    @media screen and (max-width: 800px) {
        .test2 {
            padding: 0 0.6em 0 1.7em;
        }
    }
}
```

#### output

```css
@supports (display: contents) and (display: grid) {
    .test1 {
        color: red;
    }

    [dir="ltr"] .test1 {
        left: 10px;
        text-align: left;
    }

    [dir="rtl"] .test1 {
        right: 10px;
        text-align: right;
    }
    @media screen and (max-width: 800px) {
        [dir="ltr"] .test2 {
            padding: 0 0.6em 0 1.7em;
        }

        [dir="rtl"] .test2 {
            padding: 0 1.7em 0 0.6em;
        }
    }
}
```