### PR TITLE
Fix a bug that was removing rules without declarations but with atRules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.5.3] - 2022-03-11
+
+- Fixed a bug that was removing rules without declarations but with atRules
+
 ## [3.5.2] - 2022-01-26
 
 - Move inside the both-rules-prefix, rules which override previous flipped rules

--- a/src/utilities/rules.ts
+++ b/src/utilities/rules.ts
@@ -4,7 +4,8 @@ import {
     COMMENT_TYPE,
     RTL_COMMENT_REGEXP,
     DECLARATION_TYPE,
-    RULE_TYPE
+    RULE_TYPE,
+    AT_RULE_TYPE
 } from '@constants';
 import { store } from '@data/store';
 import { addProperSelectorPrefixes } from '@utilities/selectors';
@@ -15,13 +16,17 @@ export const ruleHasDeclarations = (rule: Rule): boolean => {
     );
 };
 
-export const ruleHasChildren = (rule: Rule): boolean => {
+export const ruleHasChildren = (rule: Rule | AtRule): boolean => {
     return rule.some(
         (node: Node) => (
             node.type === DECLARATION_TYPE ||
             (
                 node.type === RULE_TYPE &&
                 ruleHasChildren(node as Rule)
+            ) ||
+            (
+                node.type === AT_RULE_TYPE &&
+                ruleHasChildren(node as AtRule)
             )
         )
     );

--- a/tests/__snapshots__/nested-rules.test.ts.snap
+++ b/tests/__snapshots__/nested-rules.test.ts.snap
@@ -144,6 +144,26 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
             padding: 0 1.7em 0 0.6em;
         }
     }
+}
+
+.test11 {
+    .test12 {
+        @media screen and (min-width: 800px) {
+            color: red;
+        }
+    }
+}
+
+[dir=\\"ltr\\"] .test11 {
+    .test13 {
+        text-align: right;
+    }
+}
+
+[dir=\\"rtl\\"] .test11 {
+    .test13 {
+        text-align: left;
+    }
 }"
 `;
 
@@ -291,6 +311,26 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
             padding: 0 1.7em 0 0.6em;
         }
     }
+}
+
+.test11 {
+    .test12 {
+        @media screen and (min-width: 800px) {
+            color: red;
+        }
+    }
+}
+
+[dir=\\"rtl\\"] .test11 {
+    .test13 {
+        text-align: right;
+    }
+}
+
+[dir=\\"ltr\\"] .test11 {
+    .test13 {
+        text-align: left;
+    }
 }"
 `;
 
@@ -416,6 +456,23 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
             padding: 0 1.7em 0 0.6em;
         }
     }
+}
+
+.test11 {
+    .test12 {
+        @media screen and (min-width: 800px) {
+            color: red;
+        }
+    }
+    .test13 {
+        text-align: right;
+    }
+}
+
+[dir=\\"rtl\\"] .test11 {
+    .test13 {
+        text-align: left;
+    }
 }"
 `;
 
@@ -540,6 +597,23 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
         [dir=\\"ltr\\"] .test10 {
             padding: 0 1.7em 0 0.6em;
         }
+    }
+}
+
+.test11 {
+    .test12 {
+        @media screen and (min-width: 800px) {
+            color: red;
+        }
+    }
+    .test13 {
+        text-align: right;
+    }
+}
+
+[dir=\\"ltr\\"] .test11 {
+    .test13 {
+        text-align: left;
     }
 }"
 `;

--- a/tests/css/input-nested.scss
+++ b/tests/css/input-nested.scss
@@ -65,3 +65,14 @@
         }
     }
 }
+
+.test11 {
+    .test12 {
+        @media screen and (min-width: 800px) {
+            color: red;
+        }
+    }
+    .test13 {
+        text-align: right;
+    }
+}


### PR DESCRIPTION
This pull request fixes a bug that was removing rules without declarations but with at-rules inside.

This code:

```scss
.b-product-single {
    &__main {
        @media screen and (min-width: 991px) {
            display: grid;
            grid-template-columns: 1fr 250px;
            grid-column-gap: var(--large-margin);
        }
    }

    &__image-wrapper {
        text-align: right;
        overflow: hidden;

        img {
            max-width: 100%;
            height: auto;
            object-fit: scale-down;
        }
    }
}
```

Was converted to:

```scss
.b-product-single {
    &__image-wrapper {
        overflow: hidden;

        img {
            max-width: 100%;
            height: auto;
            object-fit: scale-down;
        }
    }
}

[dir="ltr"] .b-product-single {
    &__image-wrapper {
        text-align: right
    }
}

[dir="rtl"] .b-product-single {
    &__image-wrapper {
        text-align: left
    }
}
```

Removing the `&__main` rule.

After this fix, the result will be:

```scss
.b-product-single {
    &__main {
        @media screen and (min-width: 991px) {
            display: grid;
            grid-template-columns: 1fr 250px;
            grid-column-gap: var(--large-margin);
        }
    }

    &__image-wrapper {
        overflow: hidden;

        img {
            max-width: 100%;
            height: auto;
            object-fit: scale-down;
        }
    }
}

[dir="ltr"] .b-product-single {
    &__image-wrapper {
        text-align: right
    }
}

[dir="rtl"] .b-product-single {
    &__image-wrapper {
        text-align: left
    }
}
```