### PR TITLE
Make type definitions CommonJS-compatible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,4 @@ const postcssRTLCSS = (options: PluginOptions = {}): Plugin => ({
 
 postcssRTLCSS.postcss = true;
 
-export default postcssRTLCSS;
+export = postcssRTLCSS;


### PR DESCRIPTION
This way require('postcss-rtlcss') in TypeScript's checkJs mode returns
the correct type.

Fixes #128.