### PR TITLE
Fix a bug with safeBothPrefix and processKeyFrames options in diff mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.6.3] - 2022-04-17
+
+- Fix a bug with `safeBothPrefix` and `processKeyFrames` options in `diff` mode
+
 ## [3.6.2] - 2022-04-12
 
 - Fix a bug with the cleaning method and @charset rules

--- a/src/parsers/declarations.ts
+++ b/src/parsers/declarations.ts
@@ -243,12 +243,8 @@ export const parseDeclarations = (
                         } else {
                             ruleFlippedSecond.append(declCloneFlipped);
                         }
-                        if (safeBothPrefix) {
-                            if (mode === Mode.diff) {
-                                appendDeclarationToRule(decl, ruleFlipped);
-                            } else {
-                                appendDeclarationToRule(decl, ruleSafe);
-                            }
+                        if (safeBothPrefix && mode !== Mode.diff) {
+                            appendDeclarationToRule(decl, ruleSafe);
                             deleteDeclarations.push(decl);
                         }
                     }

--- a/tests/__snapshots__/safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/safe-prefix.test.ts.snap
@@ -2998,8 +2998,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 .test18 {
     animation: 5s flip-rtl 1s ease-in-out,
                3s my-animation-rtl 6s ease-in-out;
-    animation: 5s flip-ltr 1s ease-in-out,
-               3s my-animation-ltr 6s ease-in-out;
     padding: 10px 10px 40px 20px;
 }
 
@@ -3028,7 +3026,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
     animation-delay: 1s;
     animation-duration: 3s;
     animation-name: my-animation-rtl;
-    animation-name: my-animation-ltr;
     animation-timing-function: ease-in-out;
 }
 
@@ -3036,7 +3033,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
     animation-delay: 2s;
     animation-duration: 4s;
     animation-name: my-animation-rtl, no-flip;
-    animation-name: my-animation-ltr, no-flip;
     animation-timing-function: ease;
 }
 
@@ -3184,7 +3180,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 
 .test44 {
     animation: 5s normalFlip-rtl 1s ease-in-out;
-    animation: 5s normalFlip-ltr 1s ease-in-out;
 }
 
 @keyframes inversedFlip-ltr {
@@ -3201,7 +3196,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 
 .test45 {
     animation: 5s inversedFlip-ltr 1s ease-in-out;
-    animation: 5s inversedFlip-rtl 1s ease-in-out;
 }
 
 @media only screen and (min-device-width: 320px) {


### PR DESCRIPTION
This pull request solves an issue in `diff` mode when the options `safeBothPrefix` and `processKeyFrames` are enable at the same time. In these conditions, the next CSS code:

```css
.test {
    animation: 5s flip 1s ease-in-out,
               3s my-animation 6s ease-in-out;
}

@keyframes flip {
    from {
        transform: translateX(100px);
    }
    to {
        transform: translateX(0);
    }
}
```

was being transformed as:

```css
.test {
    animation: 5s flip-ltr 1s ease-in-out,
               3s my-animation 6s ease-in-out;
    animation: 5s flip-rtl 1s ease-in-out,
               3s my-animation 6s ease-in-out;
}

@keyframes flip-ltr {
    from {
        transform: translateX(-100px);
    }

    to {
        transform: translateX(0);
    }
}
```

Note the double `animation` property repeating the declaration that should be overriden.