### PR TITLE
Update RTCSS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/eslint": "^8.4.2",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.35",
-    "@types/rtlcss": "^3.1.2",
+    "@types/rtlcss": "^3.5.0",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "coveralls": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,10 +872,10 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf"
   integrity sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==
 
-"@types/rtlcss@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@types/rtlcss/-/rtlcss-3.1.2.tgz#2e7b49b270b8724cdc165b1e05f7a71f5a6dc9e6"
-  integrity sha512-OUggG1uaTQzLYwssBd1PXUoQha995qTInFm5KhDs3OSHjFCkILzQle36GMy93bNf3jOquDUh/2PbrsxLZxtS+Q==
+"@types/rtlcss@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@types/rtlcss/-/rtlcss-3.5.0.tgz#9e51e49fdee6124bb759791be962f9abc6664715"
+  integrity sha512-ywnxs9c/bRgEYhSs1IEs9oEznP9aAFHV6689JKFDpeeJBFpUY8m1LqFL+RHmCfl7zU8F7S7+Af65UdFMiO06oQ==
   dependencies:
     postcss "^8.2.x"
 


### PR DESCRIPTION
[After fixing](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60454) the `processEnv` option, the `@types/rtlcss` package can be upgrade without errors.