### PR TITLE
Apply the safe prefix to logical declarations overridden by physical ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coverage/
 /index.js
 /options.d.ts
 /options.js
+.yalc/
+yalc.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.6.4] - 2022-07-20
+
+- Apply the safe prefix to logical declarations overridden by physical ones
+
 ## [3.6.3] - 2022-04-17
 
 - Fix a bug with `safeBothPrefix` and `processKeyFrames` options in `diff` mode

--- a/src/data/logical-declarations.json
+++ b/src/data/logical-declarations.json
@@ -1,0 +1,171 @@
+{
+    "border-left": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end",
+            "border-inline-end-color",
+            "border-inline-end-style",
+            "border-inline-end-width",
+            "border-inline-start",
+            "border-inline-start-color",
+            "border-inline-start-style",
+            "border-inline-start-width"
+        ]
+    },
+    "border-right": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end",
+            "border-inline-end-color",
+            "border-inline-end-style",
+            "border-inline-end-width",
+            "border-inline-start",
+            "border-inline-start-color",
+            "border-inline-start-style",
+            "border-inline-start-width"
+        ]
+    },
+    "border-left-color": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end-color",
+            "border-inline-start-color"
+        ]
+    },
+    "border-right-color": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end-color",
+            "border-inline-start-color"
+        ]
+    },
+    "border-left-style": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end-style",
+            "border-inline-start-style"
+        ]
+    },
+    "border-right-style": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end-style",
+            "border-inline-start-style"
+        ]
+    },
+    "border-left-width": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end-width",
+            "border-inline-start-width"
+        ]
+    },
+    "border-right-width": {
+        "overridden": "border",
+        "overrides": [
+            "border-inline-end-width",
+            "border-inline-start-width"
+        ]
+    },
+    "border-radius": {
+        "overridden": null,
+        "overrides": [
+            "border-start-start-radius",
+            "border-start-end-radius",
+            "border-end-start-radius",
+            "border-end-end-radius"
+        ]
+    },
+    "border-bottom-left-radius": {
+        "overridden": "border-radius",
+        "overrides": [
+            "border-end-start-radius",
+            "border-end-end-radius"
+        ]
+    },
+    "border-bottom-right-radius": {
+        "overridden": "border-radius",
+        "overrides": [
+            "border-end-start-radius",
+            "border-end-end-radius"
+        ]
+    },
+    "border-top-left-radius": {
+        "overridden": "border-radius",
+        "overrides": [
+            "border-start-start-radius",
+            "border-start-end-radius"
+        ]
+    },
+    "border-top-right-radius": {
+        "overridden": "border-radius",
+        "overrides": [
+            "border-start-start-radius",
+            "border-start-end-radius"
+        ]
+    },
+    "left": {
+        "overridden": null,
+        "overrides": [
+            "inset-inline",
+            "inset-inline-end",
+            "inset-inline-start"
+        ]
+    },
+    "right": {
+        "overridden": null,
+        "overrides": [
+            "inset-inline",
+            "inset-inline-end",
+            "inset-inline-start"
+        ]
+    },
+    "margin": {
+        "overridden": null,
+        "overrides": [
+            "margin-inline",
+            "margin-inline-end",
+            "margin-inline-start"
+        ]
+    },
+    "margin-left": {
+        "overridden": null,
+        "overrides": [
+            "margin-inline",
+            "margin-inline-end",
+            "margin-inline-start"
+        ]
+    },
+    "margin-right": {
+        "overridden": null,
+        "overrides": [
+            "margin-inline",
+            "margin-inline-end",
+            "margin-inline-start"
+        ]
+    },
+    "padding": {
+        "overridden": null,
+        "overrides": [
+            "padding-inline",
+            "padding-inline-end",
+            "padding-inline-start"
+        ]
+    },
+    "padding-left": {
+        "overridden": null,
+        "overrides": [
+            "padding-inline",
+            "padding-inline-end",
+            "padding-inline-start"
+        ]
+    },
+    "padding-right": {
+        "overridden": null,
+        "overrides": [
+            "padding-inline",
+            "padding-inline-end",
+            "padding-inline-start"
+        ]
+    }
+}


### PR DESCRIPTION
This pull request applies the `safeBothPrefix` to logical declarations overridden by physical ones.

## Input

```css
.test {
    padding-right: 20px;
    padding-inline-end: 30px;
}
```

## Output before

Note that `padding-inline-end` is being overridden by `padding-right` or `padding-left` depending on the direction.

```css
.test {
    padding-inline-end: 30px;
}

[dir="ltr"] .test {
    padding-right: 20px;
}

[dir="rtl"] .test {
    padding-left: 20px;
}
```

## Output after

```css
[dir="ltr"] .test {
    padding-right: 20px;
}

[dir="rtl"] .test {
    padding-left: 20px;
}

[dir] .test {
    padding-inline-end: 30px;
}
```