### PR TITLE
Add an option to have more control over the selector prefixing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# [3.7.0] - 2022-07-21
+
+- Add an option to have more control over the selector prefixing logic (`prefixSelectorTransformer`)
+
 ## [3.6.4] - 2022-07-20
 
 - Apply the safe prefix to logical declarations overridden by physical ones

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ All the options are optional, and a default value will be used if any of them is
 | ltrPrefix          | `string` or `string[]`    | `[dir="ltr"]`   | Prefix to use in the left-to-right CSS rules                 |
 | rtlPrefix          | `string` or `string[]`    | `[dir="rtl"]`   | Prefix to use in the right-to-left CSS rules                 |
 | bothPrefix         | `string` or `string[]`    | `[dir]`         | Prefix to create a new rule that affects both directions when the specificity of the ltr or rtl rules will override its declarations |
+| prefixSelectorTransformer | `function` | `null` | Transform function to have more control over the selectors prefixing logic |
 | safeBothPrefix     | `boolean`                 | `false`         | Add the `bothPrefix` to those declarations that can be affected by the direction to avoid them being overridden by specificity |
 | ignorePrefixedRules| `boolean`                 | true            | Ignores rules that have been prefixed with some of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix` |
 | source             | `Source (string)`         | `Source.ltr`    | The direction from which the final CSS will be generated     |
@@ -552,6 +553,84 @@ To solve this, another rule will be created at the end using the `bothPrefix` pa
 ```
 
 And no matter the direction, the `background-size` property is respected.
+
+</p>
+
+</details>
+
+---
+
+#### prefixSelectorTransformer
+
+<details><summary>Expand</summary>
+<p>
+
+This function will be used to transform the selectors and prefixing them at our will. The first parameter will be the prefix that will be used and the second the current selector:
+
+>Notes:
+>* If the function doesn‘t return a string, the default prefixing logic will be used.
+>* If this function is used, be aware that rules using `html` or `:root` will follow the custom prefixing logic. You should cover these cases.
+
+##### input
+
+```css
+.test1 {
+    left: 10px;
+    padding-right: 5px;
+    padding-inline-end: 20px;
+}
+```
+
+If the `prefixSelectorTransformer` is not sent (default):
+
+##### output 
+
+```css
+[dir="ltr"] .test1 {
+    left: 10px;
+    padding-right: 5px;
+}
+
+[dir="rtl"] .test1 {
+    right: 10px;
+    padding-left: 5px;
+}
+
+[dir] .test1 {
+    padding-inline-end: 20px;
+}
+```
+
+Setting a `prefixSelectorTransformer` function
+
+```javascript
+const options = {
+    prefixSelectorTransformer: function (prefix, selector) {
+        if (prefix === '[dir]') {
+            return `.container > ${prefix} > ${selector}`;
+        }
+        return `${selector}${prefix}`;
+    }
+};
+```
+
+##### output 
+
+```css
+.test1[dir="ltr"] {
+    left: 10px;
+    padding-right: 5px;
+}
+
+.test1[dir="rtl"] {
+    right: 10px;
+    padding-left: 5px;
+}
+
+.container > [dir] > .test1 {
+    padding-inline-end: 20px;
+}
+```
 
 </p>
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -42,11 +42,14 @@ export interface PluginStringMap {
     replace: strings;
 }
 
+export type PrefixSelectorTransformer = (prefix: string, selector: string) => string | void;
+
 export interface PluginOptions {
     mode?: ModeValues;
     ltrPrefix?: strings;
     rtlPrefix?: strings;
     bothPrefix?: strings;
+    prefixSelectorTransformer?: PrefixSelectorTransformer;
     safeBothPrefix?: boolean;
     ignorePrefixedRules?: boolean;
     source?: SourceValues;
@@ -60,8 +63,9 @@ export interface PluginOptions {
     aliases?: Record<string, string>;
 }
 
-export interface PluginOptionsNormalized extends Omit<Required<PluginOptions>, 'stringMap'> {
+export interface PluginOptionsNormalized extends Omit<Required<PluginOptions>, 'stringMap' | 'prefixSelectorTransformer'> {
     stringMap: StringMap[];
+    prefixSelectorTransformer: PrefixSelectorTransformer | null;
 }
 
 export interface RulesObject {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,7 @@ export const RULE_TYPE = 'rule';
 export const AT_RULE_TYPE = 'atrule';
 export const STRING_TYPE = 'string';
 export const BOOLEAN_TYPE = 'boolean';
+export const FUNCTION_TYPE = 'function';
 export const KEYFRAMES_NAME = 'keyframes';
 export const ANIMATION_PROP = 'animation';
 export const ANIMATION_NAME_PROP = 'animation-name';

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -17,6 +17,7 @@ import {
 } from '@types';
 import {
     BOOLEAN_TYPE,
+    FUNCTION_TYPE,
     REG_EXP_CHARACTERS_REG_EXP,
     LAST_WORD_CHARACTER_REG_EXP
 } from '@constants';
@@ -132,6 +133,7 @@ const defaultOptions = (): PluginOptionsNormalized => ({
     ltrPrefix: '[dir="ltr"]',
     rtlPrefix: '[dir="rtl"]',
     bothPrefix: '[dir]',
+    prefixSelectorTransformer: null,
     safeBothPrefix: false,
     ignorePrefixedRules: true,
     source: Source.ltr,
@@ -182,6 +184,9 @@ const normalizeOptions = (options: PluginOptions): PluginOptionsNormalized => {
     }
     if (!isNotStringOrStringArray(options.bothPrefix)) {
         returnOptions.bothPrefix = options.bothPrefix;
+    }
+    if (typeof options.prefixSelectorTransformer === FUNCTION_TYPE) {
+        returnOptions.prefixSelectorTransformer = options.prefixSelectorTransformer;
     }
     if (typeof options.safeBothPrefix === BOOLEAN_TYPE) {
         returnOptions.safeBothPrefix = options.safeBothPrefix;

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -1,9 +1,19 @@
 import { Rule } from 'postcss';
 import { strings, Mode, Source } from '@types';
-import { HTML_SELECTOR_REGEXP, ROOT_SELECTOR_REGEXP } from '@constants';
+import {
+    HTML_SELECTOR_REGEXP,
+    ROOT_SELECTOR_REGEXP,
+    STRING_TYPE
+} from '@constants';
 import { store } from '@data/store';
 
 const addPrefix = (prefix: string, selector: string): string => {
+    if (store.options.prefixSelectorTransformer) {
+        const transformedSelector = store.options.prefixSelectorTransformer(prefix, selector);
+        if (transformedSelector && typeof transformedSelector === STRING_TYPE) {
+            return transformedSelector;
+        }
+    }
     if (HTML_SELECTOR_REGEXP.test(selector)) {
         return selector.replace(HTML_SELECTOR_REGEXP, `$1${prefix}`);
     }

--- a/tests/__snapshots__/prefixes.test.ts.snap
+++ b/tests/__snapshots__/prefixes.test.ts.snap
@@ -1896,6 +1896,1254 @@ html.rtl .test50, html.right-to-left .test50 {
 }"
 `;
 
+exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with custom ltrPrefix and rtlPrefix 1`] = `
+".test1, .test2 {
+    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background-color: #FFF;
+    background-position: 10px 20px;
+    color: #666;
+    width: 100%;
+}
+
+.ltr.test1, .ltr.test2 {
+    border-radius: 0 2px 0 8px;
+    padding-right: 20px;
+    text-align: left;
+    transform: translate(-50%, 50%);
+}
+
+.rtl.test1, .rtl.test2 {
+    border-radius: 2px 0 8px 0;
+    padding-left: 20px;
+    text-align: right;
+    transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+.ltr.test2 {
+    text-align: left;
+}
+
+.rtl.test2 {
+    text-align: right;
+}
+
+.ltr.test2, .rtl.test2 {
+    text-align: center;
+}
+
+/* Comment not related to rtl */
+.test3 {
+    margin: 1px 2px 3px;
+    padding: 10px 20px;
+    /* Property comment not related to rtl */
+    text-align: center;
+}
+
+.ltr.test3 {
+    direction: ltr;
+}
+
+.rtl.test3 {
+    direction: rtl;
+}
+
+.test4 {
+    font-size: 10px;
+    border-color: red;
+    transform-origin: 10px 20px;
+    transform: scale(0.5, 0.5);
+}
+
+.ltr.test4 {
+    border-radius: 2px 4px 8px 16px;
+    text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
+}
+
+.rtl.test4 {
+    border-radius: 4px 2px 16px 8px;
+    text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
+}
+
+.test5,
+.test6,
+.test7 {
+    border: 1px solid 2px;
+    box-sizing: border-box;
+    position: absolute;
+}
+
+.ltr.test5,
+.ltr.test6,
+.ltr.test7 {
+    background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #777 #888 #999;
+    border-width: 1px 2px 3px 4px;
+    left: 100px;
+    transform: translateX(5px);
+}
+
+.rtl.test5,
+.rtl.test6,
+.rtl.test7 {
+    background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #999 #888 #777;
+    border-width: 1px 4px 3px 2px;
+    right: 100px;
+    transform: translateX(-5px);
+}
+
+/*rtl:novalid:ignore*/
+.test8 {
+    display: flex;
+    padding-left: 10%;
+}
+
+.ltr.test8 {
+    background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+.rtl.test8 {
+    background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+.test9, .test10 {
+    padding: 0px 2px 3px 4px;
+}
+
+.ltr.test9, .ltr.test10 {
+    background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: 5px;
+}
+
+.rtl.test9, .rtl.test10 {
+    background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    right: 5px;
+}
+
+.ltr.test11:hover,
+.ltr.test11:active {
+    font-family: Arial, Helvetica;
+    font-size: 20px;
+    color: '#FFF';
+    transform: translateY(10px);
+    padding: 10px;
+}
+
+.rtl.test11:hover,
+.rtl.test11:active {
+    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-size: 30px;
+    color: #000;
+    transform: translateY(10px) scaleX(-1);
+    padding: 10px 20px;
+}
+
+#test12, #test13 {
+    left: 10px;
+    position: relative;
+    text-align: right;
+}
+
+.test14 .test15 span {
+    border-left-color: #777;
+    margin: 10px 20px 30px 40px;
+    transform: translate(100%, 10%);
+}
+
+.test16 {
+    padding-right: 10px;
+}
+
+.ltr.test16:hover {
+    padding-right: 20px;
+}
+
+.rtl.test16:hover {
+    padding-left: 20px;
+}
+
+.test17 {
+    cursor: pointer;
+    padding: 10px 20px 40px 10px;
+    text-align: right;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test17 {
+        cursor: wait;
+    }
+}
+
+.test18 {
+    animation: 5s flip 1s ease-in-out,
+               3s my-animation 6s ease-in-out;
+    font-size: 10px;
+}
+
+.ltr.test18 {
+    padding: 10px 20px 40px 10px;
+}
+
+.rtl.test18 {
+    padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.ltr.test18::after {
+    left: 10px;
+}
+
+.rtl.test18::after {
+    right: 10px;
+}
+
+@keyframes flip {
+    from {
+        transform: translateX(100px);
+    }
+
+    to {
+        transform: translateX(0);
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test18 {
+        width: 100%;
+    }
+
+    .ltr.test18 {
+        padding: 1px 2px 3px 4px;
+    }
+
+    .rtl.test18 {
+        padding: 1px 4px 3px 2px;
+    }
+}
+
+.test19 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: my-animation;
+    animation-timing-function: ease-in-out;
+}
+
+.test20 {
+    animation-delay: 2s;
+    animation-duration: 4s;
+    animation-name: my-animation, no-flip;
+    animation-timing-function: ease;
+}
+
+@keyframes my-animation {
+    from {
+        left: 0%;
+    }
+
+    to {
+        left: 100%;
+    }
+}
+
+.test21 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: no-flip;
+    animation-timing-function: ease-in-out;
+    width: 100%;
+}
+
+@keyframes no-flip {
+    from {
+        color: #000;
+    }
+
+    to {
+        color: #FFF;
+    }
+}
+
+/* Do not add reset values in override mode */
+.ltr.test22 {
+    left: 5px;
+    right: 10px;
+}
+
+.rtl.test22 {
+    right: 5px;
+    left: 10px;
+}
+
+/* Do not create the RTL version if the result is the same */
+.test23 {
+    left: 10px;
+    right: 10px;
+}
+
+/* Chain override */
+.test24 {
+    padding: 10px;
+}
+
+.ltr.test24 {
+    border: 1px solid #FFF;
+}
+
+.rtl.test24 {
+    border: 1px solid #000;
+}
+
+.ltr.test24, .rtl.test24 {
+    border-bottom-color: #666;
+}
+
+/* Automatic rename */
+.test25-ltr {
+    box-sizing: border-box;
+    color: #FFF;
+    font-size: 10px;
+    width: 100%;
+}
+
+.test25, .test26-ltr, .test27 {
+    background-image: url(\\"/icons/icon-l.png\\")
+}
+
+.test26-ltr {
+    background-image: url(\\"/icons/icon-r.png\\")
+}
+
+.test27-prev {
+    background-image: url(\\"/icons/icon-p.png\\")
+}
+
+.test27-next {
+    background-image: url(\\"/icons/icon-n.png\\")
+}
+
+.test28 {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    display: inline-block;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.testleft29 {
+    border: 1px solid gray;
+}
+
+.testleft30 {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.testright30 {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.test31 {
+    border: 1px solid gray;
+}
+
+.ltr.test31 {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+.rtl.test31 {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.test32 {
+    align-items: center;
+    background-repeat: no-repeat;
+    border: 1px solid gray;    
+}
+
+.ltr.test32 {
+    background-image: url(\\"/icons/icon-left.png\\");    
+}
+
+.rtl.test32 {
+    background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+.ltr.test33 {
+    left: 10px;
+}
+
+.rtl.test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl.example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl.example35 {
+    transform: translate(10px, 20px);
+}
+
+.test36 {
+    color: #FFF;
+    width: 100%;
+}
+
+.ltr.test36 {
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.rtl.test36 {
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+}
+
+.test37 {
+    color: #FFF;
+    width: 100%;
+}
+
+.ltr.test37 {
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: right;
+}
+
+.rtl.test37 {
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: left;
+}
+
+.test38 {
+    color: #FFF;
+    width: 100%;
+}
+
+.ltr.test38 {
+    border-left: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.rtl.test38 {
+    border-right: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+}
+
+.test39 {
+    width: 50%;
+}
+
+.ltr.test39 {
+    margin-right: 10px;
+}
+
+.rtl.test39 {
+    margin-left: 10px;
+}
+
+.test40 {
+    color: transparent;
+    padding: 10px;
+}
+
+.ltr.test40 {
+    right: 5px;
+}
+
+.rtl.test40 {
+    left: 5px;
+}
+
+.test41 {
+    color: #EFEFEF;
+}
+
+.ltr.test41 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl.test41 {
+    left: 10px;
+}
+
+.ltr.test42 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.ltr.test43 {
+    transform: translate(10px, 20px);
+}
+
+@keyframes normalFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test44 {
+    animation: 5s normalFlip 1s ease-in-out;
+}
+
+@keyframes inversedFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test45 {
+    animation: 5s inversedFlip 1s ease-in-out;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test46 {
+        cursor: wait;
+    }
+
+    .ltr.test46 {
+        text-align: left;
+    }
+
+    .rtl.test46 {
+        text-align: right;
+    }
+
+    .test47 {
+        color: white;
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test48 {
+        cursor: wait;
+    }
+
+    .ltr.test48 {
+        text-align: right;
+    }
+
+    .rtl.test48 {
+        text-align: left;
+    }
+
+    .test49 {
+        color: white;
+    }
+}
+
+.ltr:root {
+    text-align: right;
+}
+
+.rtl:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html.ltr .test50 {
+    left: 10px;
+}
+
+html.rtl .test50 {
+    right: 10px;
+}
+
+.ltr.test51 {
+    border-left: 1px solid #FFF;
+}
+
+.rtl.test51 {
+    border-right: 1px solid #FFF;
+}
+
+.ltr.test51, .rtl.test51 {
+    border: none;
+}"
+`;
+
+exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with default prefixes 1`] = `
+".test1, .test2 {
+    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background-color: #FFF;
+    background-position: 10px 20px;
+    color: #666;
+    width: 100%;
+}
+
+[dir=\\"ltr\\"] > .test1, [dir=\\"ltr\\"] > .test2 {
+    border-radius: 0 2px 0 8px;
+    padding-right: 20px;
+    text-align: left;
+    transform: translate(-50%, 50%);
+}
+
+[dir=\\"rtl\\"] > .test1, [dir=\\"rtl\\"] > .test2 {
+    border-radius: 2px 0 8px 0;
+    padding-left: 20px;
+    text-align: right;
+    transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+}
+
+[dir=\\"ltr\\"] > .test2 {
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] > .test2 {
+    text-align: right;
+}
+
+[dir] > .test2 {
+    text-align: center;
+}
+
+/* Comment not related to rtl */
+.test3 {
+    margin: 1px 2px 3px;
+    padding: 10px 20px;
+    /* Property comment not related to rtl */
+    text-align: center;
+}
+
+[dir=\\"ltr\\"] > .test3 {
+    direction: ltr;
+}
+
+[dir=\\"rtl\\"] > .test3 {
+    direction: rtl;
+}
+
+.test4 {
+    font-size: 10px;
+    border-color: red;
+    transform-origin: 10px 20px;
+    transform: scale(0.5, 0.5);
+}
+
+[dir=\\"ltr\\"] > .test4 {
+    border-radius: 2px 4px 8px 16px;
+    text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
+}
+
+[dir=\\"rtl\\"] > .test4 {
+    border-radius: 4px 2px 16px 8px;
+    text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
+}
+
+.test5,
+.test6,
+.test7 {
+    border: 1px solid 2px;
+    box-sizing: border-box;
+    position: absolute;
+}
+
+[dir=\\"ltr\\"] > .test5,
+[dir=\\"ltr\\"] > .test6,
+[dir=\\"ltr\\"] > .test7 {
+    background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #777 #888 #999;
+    border-width: 1px 2px 3px 4px;
+    left: 100px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] > .test5,
+[dir=\\"rtl\\"] > .test6,
+[dir=\\"rtl\\"] > .test7 {
+    background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #999 #888 #777;
+    border-width: 1px 4px 3px 2px;
+    right: 100px;
+    transform: translateX(-5px);
+}
+
+/*rtl:novalid:ignore*/
+.test8 {
+    display: flex;
+    padding-left: 10%;
+}
+
+[dir=\\"ltr\\"] > .test8 {
+    background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+[dir=\\"rtl\\"] > .test8 {
+    background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+.test9, .test10 {
+    padding: 0px 2px 3px 4px;
+}
+
+[dir=\\"ltr\\"] > .test9, [dir=\\"ltr\\"] > .test10 {
+    background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: 5px;
+}
+
+[dir=\\"rtl\\"] > .test9, [dir=\\"rtl\\"] > .test10 {
+    background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    right: 5px;
+}
+
+[dir=\\"ltr\\"] > .test11:hover,
+[dir=\\"ltr\\"] > .test11:active {
+    font-family: Arial, Helvetica;
+    font-size: 20px;
+    color: '#FFF';
+    transform: translateY(10px);
+    padding: 10px;
+}
+
+[dir=\\"rtl\\"] > .test11:hover,
+[dir=\\"rtl\\"] > .test11:active {
+    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-size: 30px;
+    color: #000;
+    transform: translateY(10px) scaleX(-1);
+    padding: 10px 20px;
+}
+
+#test12, #test13 {
+    left: 10px;
+    position: relative;
+    text-align: right;
+}
+
+.test14 .test15 span {
+    border-left-color: #777;
+    margin: 10px 20px 30px 40px;
+    transform: translate(100%, 10%);
+}
+
+.test16 {
+    padding-right: 10px;
+}
+
+[dir=\\"ltr\\"] > .test16:hover {
+    padding-right: 20px;
+}
+
+[dir=\\"rtl\\"] > .test16:hover {
+    padding-left: 20px;
+}
+
+.test17 {
+    cursor: pointer;
+    padding: 10px 20px 40px 10px;
+    text-align: right;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test17 {
+        cursor: wait;
+    }
+}
+
+.test18 {
+    animation: 5s flip 1s ease-in-out,
+               3s my-animation 6s ease-in-out;
+    font-size: 10px;
+}
+
+[dir=\\"ltr\\"] > .test18 {
+    padding: 10px 20px 40px 10px;
+}
+
+[dir=\\"rtl\\"] > .test18 {
+    padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"ltr\\"] > .test18::after {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] > .test18::after {
+    right: 10px;
+}
+
+@keyframes flip {
+    from {
+        transform: translateX(100px);
+    }
+
+    to {
+        transform: translateX(0);
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test18 {
+        width: 100%;
+    }
+
+    [dir=\\"ltr\\"] > .test18 {
+        padding: 1px 2px 3px 4px;
+    }
+
+    [dir=\\"rtl\\"] > .test18 {
+        padding: 1px 4px 3px 2px;
+    }
+}
+
+.test19 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: my-animation;
+    animation-timing-function: ease-in-out;
+}
+
+.test20 {
+    animation-delay: 2s;
+    animation-duration: 4s;
+    animation-name: my-animation, no-flip;
+    animation-timing-function: ease;
+}
+
+@keyframes my-animation {
+    from {
+        left: 0%;
+    }
+
+    to {
+        left: 100%;
+    }
+}
+
+.test21 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: no-flip;
+    animation-timing-function: ease-in-out;
+    width: 100%;
+}
+
+@keyframes no-flip {
+    from {
+        color: #000;
+    }
+
+    to {
+        color: #FFF;
+    }
+}
+
+/* Do not add reset values in override mode */
+[dir=\\"ltr\\"] > .test22 {
+    left: 5px;
+    right: 10px;
+}
+
+[dir=\\"rtl\\"] > .test22 {
+    right: 5px;
+    left: 10px;
+}
+
+/* Do not create the RTL version if the result is the same */
+.test23 {
+    left: 10px;
+    right: 10px;
+}
+
+/* Chain override */
+.test24 {
+    padding: 10px;
+}
+
+[dir=\\"ltr\\"] > .test24 {
+    border: 1px solid #FFF;
+}
+
+[dir=\\"rtl\\"] > .test24 {
+    border: 1px solid #000;
+}
+
+[dir] > .test24 {
+    border-bottom-color: #666;
+}
+
+/* Automatic rename */
+.test25-ltr {
+    box-sizing: border-box;
+    color: #FFF;
+    font-size: 10px;
+    width: 100%;
+}
+
+.test25, .test26-ltr, .test27 {
+    background-image: url(\\"/icons/icon-l.png\\")
+}
+
+.test26-ltr {
+    background-image: url(\\"/icons/icon-r.png\\")
+}
+
+.test27-prev {
+    background-image: url(\\"/icons/icon-p.png\\")
+}
+
+.test27-next {
+    background-image: url(\\"/icons/icon-n.png\\")
+}
+
+.test28 {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    display: inline-block;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.testleft29 {
+    border: 1px solid gray;
+}
+
+.testleft30 {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.testright30 {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.test31 {
+    border: 1px solid gray;
+}
+
+[dir=\\"ltr\\"] > .test31 {
+    background-image: url(\\"/icons/icon-left.png\\");
+}
+
+[dir=\\"rtl\\"] > .test31 {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.test32 {
+    align-items: center;
+    background-repeat: no-repeat;
+    border: 1px solid gray;    
+}
+
+[dir=\\"ltr\\"] > .test32 {
+    background-image: url(\\"/icons/icon-left.png\\");    
+}
+
+[dir=\\"rtl\\"] > .test32 {
+    background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] > .test33 {
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] > .test33 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] > .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] > .example35 {
+    transform: translate(10px, 20px);
+}
+
+.test36 {
+    color: #FFF;
+    width: 100%;
+}
+
+[dir=\\"ltr\\"] > .test36 {
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] > .test36 {
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+}
+
+.test37 {
+    color: #FFF;
+    width: 100%;
+}
+
+[dir=\\"ltr\\"] > .test37 {
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] > .test37 {
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: left;
+}
+
+.test38 {
+    color: #FFF;
+    width: 100%;
+}
+
+[dir=\\"ltr\\"] > .test38 {
+    border-left: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+[dir=\\"rtl\\"] > .test38 {
+    border-right: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+}
+
+.test39 {
+    width: 50%;
+}
+
+[dir=\\"ltr\\"] > .test39 {
+    margin-right: 10px;
+}
+
+[dir=\\"rtl\\"] > .test39 {
+    margin-left: 10px;
+}
+
+.test40 {
+    color: transparent;
+    padding: 10px;
+}
+
+[dir=\\"ltr\\"] > .test40 {
+    right: 5px;
+}
+
+[dir=\\"rtl\\"] > .test40 {
+    left: 5px;
+}
+
+.test41 {
+    color: #EFEFEF;
+}
+
+[dir=\\"ltr\\"] > .test41 {
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] > .test41 {
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] > .test42 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"ltr\\"] > .test43 {
+    transform: translate(10px, 20px);
+}
+
+@keyframes normalFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test44 {
+    animation: 5s normalFlip 1s ease-in-out;
+}
+
+@keyframes inversedFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test45 {
+    animation: 5s inversedFlip 1s ease-in-out;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test46 {
+        cursor: wait;
+    }
+
+    [dir=\\"ltr\\"] > .test46 {
+        text-align: left;
+    }
+
+    [dir=\\"rtl\\"] > .test46 {
+        text-align: right;
+    }
+
+    .test47 {
+        color: white;
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test48 {
+        cursor: wait;
+    }
+
+    [dir=\\"ltr\\"] > .test48 {
+        text-align: right;
+    }
+
+    [dir=\\"rtl\\"] > .test48 {
+        text-align: left;
+    }
+
+    .test49 {
+        color: white;
+    }
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+[dir=\\"rtl\\"]:root {
+    text-align: left;
+}
+
+html .test50 {
+    color: red;
+}
+
+html[dir=\\"ltr\\"] .test50 {
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    right: 10px;
+}
+
+[dir=\\"ltr\\"] > .test51 {
+    border-left: 1px solid #FFF;
+}
+
+[dir=\\"rtl\\"] > .test51 {
+    border-right: 1px solid #FFF;
+}
+
+[dir] > .test51 {
+    border: none;
+}"
+`;
+
 exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
 ".test1, .test2 {
     border-radius: 2px 0 8px 0;
@@ -2289,6 +3537,394 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bothPr
     background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
     background-color: #FFF;
     background-position: 10px 20px;
+    border-radius: 2px 0 8px 0;
+    padding-right: 0;
+    padding-left: 20px;
+    text-align: right;
+    transform: translate(50%, 50%);
+}
+
+.test2 {
+    text-align: right;
+    text-align: center;
+}
+
+.test3 {
+    direction: rtl;
+}
+
+.test4 {
+    border-radius: 4px 2px 16px 8px;
+    text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
+}
+
+.test5,
+.test6,
+.test7 {
+    background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #999 #888 #777;
+    border-width: 1px 4px 3px 2px;
+    left: auto;
+    right: 100px;
+    transform: translateX(-5px);
+}
+
+.test8 {
+    background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+.test9, .test10 {
+    background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: auto;
+    right: 5px;
+}
+
+.test11:hover,
+.test11:active {
+    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-size: 30px;
+    color: #000;
+    transform: translateY(10px) scaleX(-1);
+    padding: 10px 20px;
+}
+
+.test16:hover {
+    padding-right: 0;
+    padding-left: 20px;
+}
+
+.test18 {
+    padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    left: auto;
+    right: 10px;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test18 {
+        padding: 1px 4px 3px 2px;
+    }
+}
+
+.test22 {
+    right: 5px;
+    left: 10px;
+}
+
+.test24 {
+    border: 1px solid #000;
+    border-bottom-color: #666;
+}
+
+.test26-ltr {
+    background-image: url(\\"/icons/icon-r.png\\")
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.test31 {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.test32 {
+    background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.example35 {
+    transform: translate(10px, 20px);
+}
+
+.test36 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test37 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test38 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test39 {
+    margin-left: 0;
+    margin-right: 10px;
+}
+
+.test40 {
+    left: auto;
+    right: 5px;
+}
+
+.test41 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.test42 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.test43 {
+    transform: translate(10px, 20px);
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test46 {
+        text-align: right;
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test48 {
+        text-align: right;
+    }
+}
+
+:root {
+    text-align: right;
+}
+
+html .test50 {
+    left: auto;
+    right: 10px;
+}
+
+.test51 {
+    border-left: none;
+    border-right: 1px solid #FFF;
+    border: none;
+}"
+`;
+
+exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with custom ltrPrefix and rtlPrefix 1`] = `
+".test1, .test2 {
+    border-radius: 2px 0 8px 0;
+    padding-right: 0;
+    padding-left: 20px;
+    text-align: right;
+    transform: translate(50%, 50%);
+}
+
+.test2 {
+    text-align: right;
+    text-align: center;
+}
+
+.test3 {
+    direction: rtl;
+}
+
+.test4 {
+    border-radius: 4px 2px 16px 8px;
+    text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
+}
+
+.test5,
+.test6,
+.test7 {
+    background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #999 #888 #777;
+    border-width: 1px 4px 3px 2px;
+    left: auto;
+    right: 100px;
+    transform: translateX(-5px);
+}
+
+.test8 {
+    background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+.test9, .test10 {
+    background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: auto;
+    right: 5px;
+}
+
+.test11:hover,
+.test11:active {
+    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-size: 30px;
+    color: #000;
+    transform: translateY(10px) scaleX(-1);
+    padding: 10px 20px;
+}
+
+.test16:hover {
+    padding-right: 0;
+    padding-left: 20px;
+}
+
+.test18 {
+    padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    left: auto;
+    right: 10px;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test18 {
+        padding: 1px 4px 3px 2px;
+    }
+}
+
+.test22 {
+    right: 5px;
+    left: 10px;
+}
+
+.test24 {
+    border: 1px solid #000;
+    border-bottom-color: #666;
+}
+
+.test26-ltr {
+    background-image: url(\\"/icons/icon-r.png\\")
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.test31 {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.test32 {
+    background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.example35 {
+    transform: translate(10px, 20px);
+}
+
+.test36 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test37 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test38 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test39 {
+    margin-left: 0;
+    margin-right: 10px;
+}
+
+.test40 {
+    left: auto;
+    right: 5px;
+}
+
+.test41 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.test42 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.test43 {
+    transform: translate(10px, 20px);
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test46 {
+        text-align: right;
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test48 {
+        text-align: right;
+    }
+}
+
+:root {
+    text-align: right;
+}
+
+html .test50 {
+    left: auto;
+    right: 10px;
+}
+
+.test51 {
+    border-left: none;
+    border-right: 1px solid #FFF;
+    border: none;
+}"
+`;
+
+exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with default prefixes 1`] = `
+".test1, .test2 {
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4210,6 +5846,1152 @@ html.rtl .test50, html.right-to-left .test50 {
 }
 
 .ltr .test51, .left-to-right .test51, .rtl .test51, .right-to-left .test51 {
+    border: none;
+}"
+`;
+
+exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with custom ltrPrefix and rtlPrefix 1`] = `
+".test1, .test2 {
+    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background-color: #FFF;
+    background-position: 10px 20px;
+    border-radius: 0 2px 0 8px;
+    color: #666;
+    padding-right: 20px;
+    text-align: left;
+    transform: translate(-50%, 50%);
+    width: 100%;
+}
+
+.rtl.test1, .rtl.test2 {
+    border-radius: 2px 0 8px 0;
+    padding-right: 0;
+    padding-left: 20px;
+    text-align: right;
+    transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+.rtl.test2 {
+    text-align: right;
+}
+
+.ltr.test2, .rtl.test2 {
+    text-align: center;
+}
+
+/* Comment not related to rtl */
+.test3 {
+    direction: ltr;
+    margin: 1px 2px 3px;
+    padding: 10px 20px;
+    /* Property comment not related to rtl */
+    text-align: center;
+}
+
+.rtl.test3 {
+    direction: rtl;
+}
+
+.test4 {
+    font-size: 10px;
+    border-color: red;
+    border-radius: 2px 4px 8px 16px;
+    text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
+    transform-origin: 10px 20px;
+    transform: scale(0.5, 0.5);
+}
+
+.rtl.test4 {
+    border-radius: 4px 2px 16px 8px;
+    text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
+}
+
+.test5,
+.test6,
+.test7 {
+    background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border: 1px solid 2px;
+    border-color: #666 #777 #888 #999;
+    box-sizing: border-box;
+    border-width: 1px 2px 3px 4px;
+    position: absolute;
+    left: 100px;
+    transform: translateX(5px);
+}
+
+.rtl.test5,
+.rtl.test6,
+.rtl.test7 {
+    background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #999 #888 #777;
+    border-width: 1px 4px 3px 2px;
+    left: auto;
+    right: 100px;
+    transform: translateX(-5px);
+}
+
+/*rtl:novalid:ignore*/
+.test8 {
+    background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
+    display: flex;
+    padding-left: 10%;
+}
+
+.rtl.test8 {
+    background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+.test9, .test10 {
+    background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: 5px;
+    padding: 0px 2px 3px 4px;
+}
+
+.rtl.test9, .rtl.test10 {
+    background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: auto;
+    right: 5px;
+}
+
+.test11:hover,
+.test11:active {
+    font-family: Arial, Helvetica;
+    font-size: 20px;
+    color: '#FFF';
+    transform: translateY(10px);
+    padding: 10px;
+}
+
+.rtl.test11:hover,
+.rtl.test11:active {
+    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-size: 30px;
+    color: #000;
+    transform: translateY(10px) scaleX(-1);
+    padding: 10px 20px;
+}
+
+#test12, #test13 {
+    left: 10px;
+    position: relative;
+    text-align: right;
+}
+
+.test14 .test15 span {
+    border-left-color: #777;
+    margin: 10px 20px 30px 40px;
+    transform: translate(100%, 10%);
+}
+
+.test16 {
+    padding-right: 10px;
+}
+
+.test16:hover {
+    padding-right: 20px;
+}
+
+.rtl.test16:hover {
+    padding-right: 0;
+    padding-left: 20px;
+}
+
+.test17 {
+    cursor: pointer;
+    padding: 10px 20px 40px 10px;
+    text-align: right;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test17 {
+        cursor: wait;
+    }
+}
+
+.test18 {
+    animation: 5s flip 1s ease-in-out,
+               3s my-animation 6s ease-in-out;
+    font-size: 10px;
+    padding: 10px 20px 40px 10px;
+}
+
+.rtl.test18 {
+    padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+.rtl.test18::after {
+    left: auto;
+    right: 10px;
+}
+
+@keyframes flip {
+    from {
+        transform: translateX(100px);
+    }
+
+    to {
+        transform: translateX(0);
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test18 {
+        padding: 1px 2px 3px 4px;
+        width: 100%;
+    }
+
+    .rtl.test18 {
+        padding: 1px 4px 3px 2px;
+    }
+}
+
+.test19 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: my-animation;
+    animation-timing-function: ease-in-out;
+}
+
+.test20 {
+    animation-delay: 2s;
+    animation-duration: 4s;
+    animation-name: my-animation, no-flip;
+    animation-timing-function: ease;
+}
+
+@keyframes my-animation {
+    from {
+        left: 0%;
+    }
+
+    to {
+        left: 100%;
+    }
+}
+
+.test21 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: no-flip;
+    animation-timing-function: ease-in-out;
+    width: 100%;
+}
+
+@keyframes no-flip {
+    from {
+        color: #000;
+    }
+
+    to {
+        color: #FFF;
+    }
+}
+
+/* Do not add reset values in override mode */
+.test22 {
+    left: 5px;
+    right: 10px;
+}
+
+.rtl.test22 {
+    right: 5px;
+    left: 10px;
+}
+
+/* Do not create the RTL version if the result is the same */
+.test23 {
+    left: 10px;
+    right: 10px;
+}
+
+/* Chain override */
+.test24 {
+    border: 1px solid #FFF;
+    padding: 10px;
+}
+
+.rtl.test24 {
+    border: 1px solid #000;
+}
+
+.ltr.test24, .rtl.test24 {
+    border-bottom-color: #666;
+}
+
+/* Automatic rename */
+.test25-ltr {
+    box-sizing: border-box;
+    color: #FFF;
+    font-size: 10px;
+    width: 100%;
+}
+
+.test25, .test26-ltr, .test27 {
+    background-image: url(\\"/icons/icon-l.png\\")
+}
+
+.test26-ltr {
+    background-image: url(\\"/icons/icon-r.png\\")
+}
+
+.test27-prev {
+    background-image: url(\\"/icons/icon-p.png\\")
+}
+
+.test27-next {
+    background-image: url(\\"/icons/icon-n.png\\")
+}
+
+.test28 {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    display: inline-block;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.testleft29 {
+    border: 1px solid gray;
+}
+
+.testleft30 {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.testright30 {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.test31 {
+    background-image: url(\\"/icons/icon-left.png\\");
+    border: 1px solid gray;
+}
+
+.rtl.test31 {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.test32 {
+    align-items: center;
+    background-image: url(\\"/icons/icon-left.png\\");
+    background-repeat: no-repeat;
+    border: 1px solid gray;    
+}
+
+.rtl.test32 {
+    background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+.rtl.test33 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.rtl.example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.rtl.example35 {
+    transform: translate(10px, 20px);
+}
+
+.test36 {
+    color: #FFF;
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+    width: 100%;
+}
+
+.ltr.test36 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test37 {
+    color: #FFF;
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+    width: 100%;
+}
+
+.rtl.test37 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+}
+
+.ltr.test37 {
+    text-align: right;
+}
+
+.test38 {
+    color: #FFF;
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+    width: 100%;
+}
+
+.rtl.test38 {
+    border-left: none;
+    border-right: 1px solid #666;
+}
+
+.ltr.test38 {
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test39 {
+    margin-left: 10px;
+    width: 50%;
+}
+
+.ltr.test39 {
+    margin-left: 0;
+    margin-right: 10px;
+}
+
+.test40 {
+    color: transparent;
+    padding: 10px;
+    left: 5px;
+}
+
+.ltr.test40 {
+    left: auto;
+    right: 5px;
+}
+
+.test41 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+.ltr.test41 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+.ltr.test42 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+.ltr.test43 {
+    transform: translate(10px, 20px);
+}
+
+@keyframes normalFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test44 {
+    animation: 5s normalFlip 1s ease-in-out;
+}
+
+@keyframes inversedFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test45 {
+    animation: 5s inversedFlip 1s ease-in-out;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test46 {
+        cursor: wait;
+        text-align: left;
+    }
+
+    .rtl.test46 {
+        text-align: right;
+    }
+
+    .test47 {
+        color: white;
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test48 {
+        cursor: wait;
+        text-align: left;
+    }
+
+    .ltr.test48 {
+        text-align: right;
+    }
+
+    .test49 {
+        color: white;
+    }
+}
+
+:root {
+    text-align: left;
+}
+
+.ltr:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html.rtl .test50 {
+    left: auto;
+    right: 10px;
+}
+
+.test51 {
+    border-left: 1px solid #FFF;
+}
+
+.rtl.test51 {
+    border-left: none;
+    border-right: 1px solid #FFF;
+}
+
+.ltr.test51, .rtl.test51 {
+    border: none;
+}"
+`;
+
+exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with default prefixes 1`] = `
+".test1, .test2 {
+    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background-color: #FFF;
+    background-position: 10px 20px;
+    border-radius: 0 2px 0 8px;
+    color: #666;
+    padding-right: 20px;
+    text-align: left;
+    transform: translate(-50%, 50%);
+    width: 100%;
+}
+
+[dir=\\"rtl\\"] > .test1, [dir=\\"rtl\\"] > .test2 {
+    border-radius: 2px 0 8px 0;
+    padding-right: 0;
+    padding-left: 20px;
+    text-align: right;
+    transform: translate(50%, 50%);
+}
+
+.test2 {
+    color: red;
+    text-align: left;
+}
+
+[dir=\\"rtl\\"] > .test2 {
+    text-align: right;
+}
+
+[dir] > .test2 {
+    text-align: center;
+}
+
+/* Comment not related to rtl */
+.test3 {
+    direction: ltr;
+    margin: 1px 2px 3px;
+    padding: 10px 20px;
+    /* Property comment not related to rtl */
+    text-align: center;
+}
+
+[dir=\\"rtl\\"] > .test3 {
+    direction: rtl;
+}
+
+.test4 {
+    font-size: 10px;
+    border-color: red;
+    border-radius: 2px 4px 8px 16px;
+    text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
+    transform-origin: 10px 20px;
+    transform: scale(0.5, 0.5);
+}
+
+[dir=\\"rtl\\"] > .test4 {
+    border-radius: 4px 2px 16px 8px;
+    text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
+}
+
+.test5,
+.test6,
+.test7 {
+    background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border: 1px solid 2px;
+    border-color: #666 #777 #888 #999;
+    box-sizing: border-box;
+    border-width: 1px 2px 3px 4px;
+    position: absolute;
+    left: 100px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] > .test5,
+[dir=\\"rtl\\"] > .test6,
+[dir=\\"rtl\\"] > .test7 {
+    background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
+    border-color: #666 #999 #888 #777;
+    border-width: 1px 4px 3px 2px;
+    left: auto;
+    right: 100px;
+    transform: translateX(-5px);
+}
+
+/*rtl:novalid:ignore*/
+.test8 {
+    background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
+    display: flex;
+    padding-left: 10%;
+}
+
+[dir=\\"rtl\\"] > .test8 {
+    background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
+}
+
+.test9, .test10 {
+    background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: 5px;
+    padding: 0px 2px 3px 4px;
+}
+
+[dir=\\"rtl\\"] > .test9, [dir=\\"rtl\\"] > .test10 {
+    background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
+                linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
+                linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+    left: auto;
+    right: 5px;
+}
+
+.test11:hover,
+.test11:active {
+    font-family: Arial, Helvetica;
+    font-size: 20px;
+    color: '#FFF';
+    transform: translateY(10px);
+    padding: 10px;
+}
+
+[dir=\\"rtl\\"] > .test11:hover,
+[dir=\\"rtl\\"] > .test11:active {
+    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-size: 30px;
+    color: #000;
+    transform: translateY(10px) scaleX(-1);
+    padding: 10px 20px;
+}
+
+#test12, #test13 {
+    left: 10px;
+    position: relative;
+    text-align: right;
+}
+
+.test14 .test15 span {
+    border-left-color: #777;
+    margin: 10px 20px 30px 40px;
+    transform: translate(100%, 10%);
+}
+
+.test16 {
+    padding-right: 10px;
+}
+
+.test16:hover {
+    padding-right: 20px;
+}
+
+[dir=\\"rtl\\"] > .test16:hover {
+    padding-right: 0;
+    padding-left: 20px;
+}
+
+.test17 {
+    cursor: pointer;
+    padding: 10px 20px 40px 10px;
+    text-align: right;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test17 {
+        cursor: wait;
+    }
+}
+
+.test18 {
+    animation: 5s flip 1s ease-in-out,
+               3s my-animation 6s ease-in-out;
+    font-size: 10px;
+    padding: 10px 20px 40px 10px;
+}
+
+[dir=\\"rtl\\"] > .test18 {
+    padding: 10px 10px 40px 20px;
+}
+
+.test18::after {
+    content: '';
+    left: 10px;
+    text-align: left;
+    padding-left: 5px;
+    margin-left: 15px;
+    transform: translateX(5px);
+}
+
+[dir=\\"rtl\\"] > .test18::after {
+    left: auto;
+    right: 10px;
+}
+
+@keyframes flip {
+    from {
+        transform: translateX(100px);
+    }
+
+    to {
+        transform: translateX(0);
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test18 {
+        padding: 1px 2px 3px 4px;
+        width: 100%;
+    }
+
+    [dir=\\"rtl\\"] > .test18 {
+        padding: 1px 4px 3px 2px;
+    }
+}
+
+.test19 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: my-animation;
+    animation-timing-function: ease-in-out;
+}
+
+.test20 {
+    animation-delay: 2s;
+    animation-duration: 4s;
+    animation-name: my-animation, no-flip;
+    animation-timing-function: ease;
+}
+
+@keyframes my-animation {
+    from {
+        left: 0%;
+    }
+
+    to {
+        left: 100%;
+    }
+}
+
+.test21 {
+    animation-delay: 1s;
+    animation-duration: 3s;
+    animation-name: no-flip;
+    animation-timing-function: ease-in-out;
+    width: 100%;
+}
+
+@keyframes no-flip {
+    from {
+        color: #000;
+    }
+
+    to {
+        color: #FFF;
+    }
+}
+
+/* Do not add reset values in override mode */
+.test22 {
+    left: 5px;
+    right: 10px;
+}
+
+[dir=\\"rtl\\"] > .test22 {
+    right: 5px;
+    left: 10px;
+}
+
+/* Do not create the RTL version if the result is the same */
+.test23 {
+    left: 10px;
+    right: 10px;
+}
+
+/* Chain override */
+.test24 {
+    border: 1px solid #FFF;
+    padding: 10px;
+}
+
+[dir=\\"rtl\\"] > .test24 {
+    border: 1px solid #000;
+}
+
+[dir] > .test24 {
+    border-bottom-color: #666;
+}
+
+/* Automatic rename */
+.test25-ltr {
+    box-sizing: border-box;
+    color: #FFF;
+    font-size: 10px;
+    width: 100%;
+}
+
+.test25, .test26-ltr, .test27 {
+    background-image: url(\\"/icons/icon-l.png\\")
+}
+
+.test26-ltr {
+    background-image: url(\\"/icons/icon-r.png\\")
+}
+
+.test27-prev {
+    background-image: url(\\"/icons/icon-p.png\\")
+}
+
+.test27-next {
+    background-image: url(\\"/icons/icon-n.png\\")
+}
+
+.test28 {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    display: inline-block;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.test28-left::before {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.testleft29 {
+    border: 1px solid gray;
+}
+
+.testleft30 {
+    content: \\"keyboard_arrow_left\\";
+}
+
+.testright30 {
+    content: \\"keyboard_arrow_right\\";
+}
+
+.test31 {
+    background-image: url(\\"/icons/icon-left.png\\");
+    border: 1px solid gray;
+}
+
+[dir=\\"rtl\\"] > .test31 {
+    background-image: url(\\"/icons/icon-right.png\\");
+}
+
+.test32 {
+    align-items: center;
+    background-image: url(\\"/icons/icon-left.png\\");
+    background-repeat: no-repeat;
+    border: 1px solid gray;    
+}
+
+[dir=\\"rtl\\"] > .test32 {
+    background-image: url(\\"/icons/icon-right.png\\");    
+}
+
+.test33 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"rtl\\"] > .test33 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"rtl\\"] > .example34 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"rtl\\"] > .example35 {
+    transform: translate(10px, 20px);
+}
+
+.test36 {
+    color: #FFF;
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+    width: 100%;
+}
+
+[dir=\\"ltr\\"] > .test36 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test37 {
+    color: #FFF;
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+    width: 100%;
+}
+
+[dir=\\"rtl\\"] > .test37 {
+    border-left: none;
+    border-right: 1px solid #666;
+    padding: 10px 20px 10px 5px;
+}
+
+[dir=\\"ltr\\"] > .test37 {
+    text-align: right;
+}
+
+.test38 {
+    color: #FFF;
+    border-left: 1px solid #666;
+    padding: 10px 5px 10px 20px;
+    text-align: left;
+    width: 100%;
+}
+
+[dir=\\"rtl\\"] > .test38 {
+    border-left: none;
+    border-right: 1px solid #666;
+}
+
+[dir=\\"ltr\\"] > .test38 {
+    padding: 10px 20px 10px 5px;
+    text-align: right;
+}
+
+.test39 {
+    margin-left: 10px;
+    width: 50%;
+}
+
+[dir=\\"ltr\\"] > .test39 {
+    margin-left: 0;
+    margin-right: 10px;
+}
+
+.test40 {
+    color: transparent;
+    padding: 10px;
+    left: 5px;
+}
+
+[dir=\\"ltr\\"] > .test40 {
+    left: auto;
+    right: 5px;
+}
+
+.test41 {
+    color: #EFEFEF;
+    left: 10px;
+}
+
+[dir=\\"ltr\\"] > .test41 {
+    left: auto;
+    right: 10px;
+    height: 50px;
+    width: 100px;
+}
+
+[dir=\\"ltr\\"] > .test42 {
+    color: #EFEFEF;
+    left: 10px;
+    width: 100%;    
+}
+
+[dir=\\"ltr\\"] > .test43 {
+    transform: translate(10px, 20px);
+}
+
+@keyframes normalFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test44 {
+    animation: 5s normalFlip 1s ease-in-out;
+}
+
+@keyframes inversedFlip {
+    from {
+        left: 0px;
+        top: 0px;
+    }
+
+    to {
+        left: 100px;
+        top: -100px;
+    }
+}
+
+.test45 {
+    animation: 5s inversedFlip 1s ease-in-out;
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test46 {
+        cursor: wait;
+        text-align: left;
+    }
+
+    [dir=\\"rtl\\"] > .test46 {
+        text-align: right;
+    }
+
+    .test47 {
+        color: white;
+    }
+}
+
+@media only screen and (min-device-width: 320px) {
+    .test48 {
+        cursor: wait;
+        text-align: left;
+    }
+
+    [dir=\\"ltr\\"] > .test48 {
+        text-align: right;
+    }
+
+    .test49 {
+        color: white;
+    }
+}
+
+:root {
+    text-align: left;
+}
+
+[dir=\\"ltr\\"]:root {
+    text-align: right;
+}
+
+html .test50 {
+    color: red;
+    left: 10px;
+}
+
+html[dir=\\"rtl\\"] .test50 {
+    left: auto;
+    right: 10px;
+}
+
+.test51 {
+    border-left: 1px solid #FFF;
+}
+
+[dir=\\"rtl\\"] > .test51 {
+    border-left: none;
+    border-right: 1px solid #FFF;
+}
+
+[dir] > .test51 {
     border: none;
 }"
 `;

--- a/tests/prefixes.test.ts
+++ b/tests/prefixes.test.ts
@@ -14,21 +14,67 @@ runTests({}, (pluginOptions: PluginOptions): void => {
     });
   
     it('custom ltrPrefix and rtlPrefix', (): void => {
-      const options: PluginOptions = { ...pluginOptions, ltrPrefix: '.ltr', rtlPrefix: '.rtl', bothPrefix: ['.ltr', '.rtl'] };
+      const options: PluginOptions = {
+        ...pluginOptions,
+        ltrPrefix: '.ltr',
+        rtlPrefix: '.rtl',
+        bothPrefix: ['.ltr', '.rtl']
+      };
       const output = postcss([postcssRTLCSS(options)]).process(input);
       expect(output.css).toMatchSnapshot();
       expect(output.warnings()).toHaveLength(0);
     });
   
     it('custom ltrPrefix and rtlPrefix properties as arrays', (): void => {
-      const options: PluginOptions = { ...pluginOptions, ltrPrefix: ['.ltr', '.left-to-right'], rtlPrefix: ['.rtl', '.right-to-left'], bothPrefix: ['.ltr', '.left-to-right', '.rtl', '.right-to-left'] };
+      const options: PluginOptions = {
+        ...pluginOptions,
+        ltrPrefix: ['.ltr', '.left-to-right'],
+        rtlPrefix: ['.rtl', '.right-to-left'],
+        bothPrefix: ['.ltr', '.left-to-right', '.rtl', '.right-to-left']
+      };
       const output = postcss([postcssRTLCSS(options)]).process(input);
       expect(output.css).toMatchSnapshot();
       expect(output.warnings()).toHaveLength(0);
     });
   
     it('custom ltrPrefix, rtlPrefix, and bothPrefix properties as arrays and processUrls: true', (): void => {
-      const options: PluginOptions = { ...pluginOptions, ltrPrefix: ['.ltr', '.left-to-right'], rtlPrefix: ['.rtl', '.right-to-left'], bothPrefix: ['.ltr', '.left-to-right', '.rtl', '.right-to-left'], processUrls: true };
+      const options: PluginOptions = {
+        ...pluginOptions,
+        ltrPrefix: ['.ltr', '.left-to-right'],
+        rtlPrefix: ['.rtl', '.right-to-left'],
+        bothPrefix: ['.ltr', '.left-to-right', '.rtl', '.right-to-left'],
+        processUrls: true
+      };
+      const output = postcss([postcssRTLCSS(options)]).process(input);
+      expect(output.css).toMatchSnapshot();
+      expect(output.warnings()).toHaveLength(0);
+    });
+
+    it('prefixSelectorTransformer with default prefixes', (): void => {
+      const transformer = (prefix: string, selector: string) => {
+        if (!selector.startsWith('html') && selector.indexOf(':root') < 0) {
+          return `${prefix} > ${selector}`;
+        }
+      };
+      const options: PluginOptions = { ...pluginOptions, prefixSelectorTransformer: transformer };
+      const output = postcss([postcssRTLCSS(options)]).process(input);
+      expect(output.css).toMatchSnapshot();
+      expect(output.warnings()).toHaveLength(0);
+    });
+
+    it('prefixSelectorTransformer with custom ltrPrefix and rtlPrefix', (): void => {
+      const transformer = (prefix: string, selector: string) => {
+        if (!selector.startsWith('html') && selector.indexOf(':root') < 0) {
+          return `${prefix}${selector}`;
+        }
+      };
+      const options: PluginOptions = {
+        ...pluginOptions,
+        prefixSelectorTransformer: transformer,
+        ltrPrefix: '.ltr',
+        rtlPrefix: '.rtl',
+        bothPrefix: ['.ltr', '.rtl']
+      };
       const output = postcss([postcssRTLCSS(options)]).process(input);
       expect(output.css).toMatchSnapshot();
       expect(output.warnings()).toHaveLength(0);


### PR DESCRIPTION
This pull request adds a new option to transform the prefixing logic of the selectors at our will.

#### prefixSelectorTransformer

This function will be used to transform the selectors and prefixing them at our will. The first parameter will be the prefix that will be used and the second the current selector:

>Notes:
>* If the function doesn‘t return a string, the default prefixing logic will be used.
>* If this function is used, be aware that rules using `html` or `:root` will follow the custom prefixing logic. You should cover these cases.

##### input

```css
.test1 {
    left: 10px;
    padding-right: 5px;
    padding-inline-end: 20px;
}
```

If the `prefixSelectorTransformer` is not sent (default):

##### output 

```css
[dir="ltr"] .test1 {
    left: 10px;
    padding-right: 5px;
}

[dir="rtl"] .test1 {
    right: 10px;
    padding-left: 5px;
}

[dir] .test1 {
    padding-inline-end: 20px;
}
```

Setting a `prefixSelectorTransformer` function

```javascript
const options = {
    prefixSelectorTransformer: function (prefix, selector) {
        if (prefix === '[dir]') {
            return `.container > ${prefix} > ${selector}`;
        }
        return `${selector}${prefix}`;
    }
};
```

##### output 

```css
.test1[dir="ltr"] {
    left: 10px;
    padding-right: 5px;
}

.test1[dir="rtl"] {
    right: 10px;
    padding-left: 5px;
}

.container > [dir] > .test1 {
    padding-inline-end: 20px;
}
```