### PR TITLE
Improve declaration overriding logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# [3.7.1] - 2022-07-24
+
+- Improve the overriding logic to avoid edge cases with multiple overrides
+
 # [3.7.0] - 2022-07-21
 
 - Add an option to have more control over the selector prefixing logic (`prefixSelectorTransformer`)

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,4 +1,8 @@
-import { Rule, AtRule } from 'postcss';
+import {
+    Rule,
+    AtRule,
+    Declaration
+} from 'postcss';
 
 export enum Mode {
     combined = 'combined',
@@ -103,3 +107,5 @@ export interface ControlDirective {
     directive: string;
     option?: string;
 }
+
+export type DeclarationHashMapProp = Record<string, Record<string, { decl: Declaration; value: string; }>>;

--- a/tests/__snapshots__/autorename.test.ts.snap
+++ b/tests/__snapshots__/autorename.test.ts.snap
@@ -25,17 +25,7 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -649,17 +639,7 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -1273,17 +1253,7 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -1897,17 +1867,7 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -2521,17 +2481,7 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -3145,17 +3095,7 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -3769,17 +3709,7 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -4377,11 +4307,6 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -4584,11 +4509,6 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible with custom string map 1`] =
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -4803,11 +4723,6 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible, greedy: true 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -5020,11 +4935,6 @@ exports[`[[Mode: diff]] Autorename Tests:  only control directives 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -5212,11 +5122,6 @@ exports[`[[Mode: diff]] Autorename Tests:  only control directives, greedy: true
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -5410,11 +5315,6 @@ exports[`[[Mode: diff]] Autorename Tests:  strict 1`] = `
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -5612,11 +5512,6 @@ exports[`[[Mode: diff]] Autorename Tests:  strict, greedy: true 1`] = `
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -5839,13 +5734,6 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -6412,13 +6300,6 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -6985,13 +6866,6 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -7558,13 +7432,6 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -8131,13 +7998,6 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -8704,13 +8564,6 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -9277,13 +9130,6 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 

--- a/tests/__snapshots__/basic-options.test.ts.snap
+++ b/tests/__snapshots__/basic-options.test.ts.snap
@@ -25,17 +25,7 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -721,17 +711,7 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -1345,17 +1325,7 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
 
 .test2 {
     color: red;
-}
-
-[dir=\\"rtl\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"ltr\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -2037,17 +2007,7 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"rtl\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"ltr\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -2662,17 +2622,7 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -3287,17 +3237,7 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -3895,11 +3835,6 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processKeyFrames: true} 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -4154,11 +4089,6 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -4346,11 +4276,6 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl, processKeyFrames: tr
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -4604,11 +4529,6 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -4799,11 +4719,6 @@ exports[`[[Mode: diff]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -4992,11 +4907,6 @@ exports[`[[Mode: diff]] Basic Options Tests:  Basic 1`] = `
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -5203,13 +5113,6 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -5842,13 +5745,6 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -6415,13 +6311,6 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"ltr\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -7044,13 +6933,6 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"ltr\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -7612,13 +7494,6 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -8186,13 +8061,6 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 

--- a/tests/__snapshots__/overriding.test.ts.snap
+++ b/tests/__snapshots__/overriding.test.ts.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: combined]] Overriding Tests:  Basic 1`] = `
+"/* Mirror properties, do nothing */
+.test1 {
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+/* Mirror properties, do nothing */
+.test2 {
+    margin-left: 5px;
+    margin-right: 5px;
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+/* Flipped-declarations overriden by non-flipped declarations, do nothing */
+.test3 {
+    text-align: left;
+    text-align: right;
+    text-align: center;
+}
+
+/* Overriden mirror properties */
+.test4 {
+    left: 0;
+    right: 10px;
+}
+
+[dir=\\"ltr\\"] .test4 {
+    left: 10px;
+    right: 0;
+}
+
+[dir=\\"rtl\\"] .test4 {
+    right: 10px;
+    left: 0;
+}"
+`;
+
+exports[`[[Mode: diff]] Overriding Tests:  Basic 1`] = `
+".test4 {
+    right: 10px;
+    left: 0;
+}"
+`;
+
+exports[`[[Mode: override]] Overriding Tests:  Basic 1`] = `
+"/* Mirror properties, do nothing */
+.test1 {
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+/* Mirror properties, do nothing */
+.test2 {
+    margin-left: 5px;
+    margin-right: 5px;
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+/* Flipped-declarations overriden by non-flipped declarations, do nothing */
+.test3 {
+    text-align: left;
+    text-align: right;
+    text-align: center;
+}
+
+/* Overriden mirror properties */
+.test4 {
+    left: 0;
+    left: 10px;
+    right: 10px;
+    right: 0;
+}
+
+[dir=\\"rtl\\"] .test4 {
+    right: 10px;
+    left: 0;
+}"
+`;

--- a/tests/__snapshots__/prefixes.test.ts.snap
+++ b/tests/__snapshots__/prefixes.test.ts.snap
@@ -25,17 +25,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 
 .test2 {
     color: red;
-}
-
-.ltr .test2 {
     text-align: left;
-}
-
-.rtl .test2 {
-    text-align: right;
-}
-
-.ltr .test2, .rtl .test2 {
     text-align: center;
 }
 
@@ -649,17 +639,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 
 .test2 {
     color: red;
-}
-
-.ltr .test2, .left-to-right .test2 {
     text-align: left;
-}
-
-.rtl .test2, .right-to-left .test2 {
-    text-align: right;
-}
-
-.ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     text-align: center;
 }
 
@@ -1287,17 +1267,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 
 .test2 {
     color: red;
-}
-
-.ltr .test2, .left-to-right .test2 {
     text-align: left;
-}
-
-.rtl .test2, .right-to-left .test2 {
-    text-align: right;
-}
-
-.ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     text-align: center;
 }
 
@@ -1921,17 +1891,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 
 .test2 {
     color: red;
-}
-
-.ltr.test2 {
     text-align: left;
-}
-
-.rtl.test2 {
-    text-align: right;
-}
-
-.ltr.test2, .rtl.test2 {
     text-align: center;
 }
 
@@ -2545,17 +2505,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] > .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] > .test2 {
-    text-align: right;
-}
-
-[dir] > .test2 {
     text-align: center;
 }
 
@@ -3153,11 +3103,6 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -3345,11 +3290,6 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix properti
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -3544,11 +3484,6 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bothPr
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -3738,11 +3673,6 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with custom l
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -3930,11 +3860,6 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with default 
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -4141,13 +4066,6 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 .test2 {
     color: red;
     text-align: left;
-}
-
-.rtl .test2 {
-    text-align: right;
-}
-
-.ltr .test2, .rtl .test2 {
     text-align: center;
 }
 
@@ -4714,13 +4632,6 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 .test2 {
     color: red;
     text-align: left;
-}
-
-.rtl .test2, .right-to-left .test2 {
-    text-align: right;
-}
-
-.ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     text-align: center;
 }
 
@@ -5296,13 +5207,6 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 .test2 {
     color: red;
     text-align: left;
-}
-
-.rtl .test2, .right-to-left .test2 {
-    text-align: right;
-}
-
-.ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     text-align: center;
 }
 
@@ -5874,13 +5778,6 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with cust
 .test2 {
     color: red;
     text-align: left;
-}
-
-.rtl.test2 {
-    text-align: right;
-}
-
-.ltr.test2, .rtl.test2 {
     text-align: center;
 }
 
@@ -6447,13 +6344,6 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] > .test2 {
-    text-align: right;
-}
-
-[dir] > .test2 {
     text-align: center;
 }
 

--- a/tests/__snapshots__/safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/safe-prefix.test.ts.snap
@@ -28,14 +28,7 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {
@@ -675,14 +668,7 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {
@@ -1388,14 +1374,7 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {
@@ -2035,14 +2014,7 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir=\\"rtl\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"ltr\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {
@@ -2667,7 +2639,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} 1`]
 }
 
 .test2 {
-    text-align: right;
     text-align: center;
 }
 
@@ -2932,7 +2903,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 }
 
 .test2 {
-    text-align: right;
     text-align: center;
 }
 
@@ -3241,7 +3211,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 }
 
 .test2 {
-    text-align: right;
     text-align: center;
 }
 
@@ -3506,7 +3475,6 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 }
 
 .test2 {
-    text-align: right;
     text-align: center;
 }
 
@@ -3784,14 +3752,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {
@@ -4420,14 +4381,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {
@@ -5122,14 +5076,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {
@@ -5758,14 +5705,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 .test2 {
     color: red;
-}
-
-[dir] .test2 {
     text-align: left;
-}
-
-[dir=\\"ltr\\"] .test2 {
-    text-align: right;
 }
 
 [dir] .test2 {

--- a/tests/__snapshots__/string-map.test.ts.snap
+++ b/tests/__snapshots__/string-map.test.ts.snap
@@ -29,17 +29,7 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -657,17 +647,7 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -1285,17 +1265,7 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -1913,17 +1883,7 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
 
 .test2 {
     color: red;
-}
-
-[dir=\\"ltr\\"] .test2 {
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -2524,11 +2484,6 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -2721,11 +2676,6 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
     transform: translate(50%, 50%);
 }
 
-.test2 {
-    text-align: right;
-    text-align: center;
-}
-
 .test3 {
     direction: rtl;
 }
@@ -2916,11 +2866,6 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map and processUrls: tr
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -3117,11 +3062,6 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map without names and p
     padding-left: 20px;
     text-align: right;
     transform: translate(50%, 50%);
-}
-
-.test2 {
-    text-align: right;
-    text-align: center;
 }
 
 .test3 {
@@ -3336,13 +3276,6 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -3913,13 +3846,6 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -4490,13 +4416,6 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 
@@ -5067,13 +4986,6 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
 .test2 {
     color: red;
     text-align: left;
-}
-
-[dir=\\"rtl\\"] .test2 {
-    text-align: right;
-}
-
-[dir] .test2 {
     text-align: center;
 }
 

--- a/tests/css/overriding.css
+++ b/tests/css/overriding.css
@@ -1,0 +1,30 @@
+/* Mirror properties, do nothing */
+.test1 {
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+/* Mirror properties, do nothing */
+.test2 {
+    margin-left: 5px;
+    margin-right: 5px;
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+/* Flipped-declarations overriden by non-flipped declarations, do nothing */
+.test3 {
+    text-align: left;
+    text-align: right;
+    text-align: center;
+}
+
+/* Overriden mirror properties */
+.test4 {
+    left: 0;
+    left: 10px;
+    right: 10px;
+    right: 0;
+}

--- a/tests/overriding.test.ts
+++ b/tests/overriding.test.ts
@@ -1,0 +1,25 @@
+import postcss from 'postcss';
+import postcssRTLCSS from '../src';
+import { PluginOptions, Source } from '../src/@types';
+import { readCSSFile, runTests } from './utils';
+
+runTests({}, (pluginOptions: PluginOptions): void => {
+
+  describe(`[[Mode: ${pluginOptions.mode}]] Overriding Tests: `, (): void => {
+
+    let input = '';
+  
+    beforeEach(async (): Promise<void> => {
+      input = input || await readCSSFile('overriding.css');
+    });
+  
+    it('Basic', (): void => {
+      const options: PluginOptions = { ...pluginOptions };
+      const output = postcss([postcssRTLCSS(options)]).process(input);
+      expect(output.css).toMatchSnapshot();
+      expect(output.warnings()).toHaveLength(0);
+    });
+  
+  });
+
+});


### PR DESCRIPTION
This merge request improves the overriding logic to cover multiple cases in which it was failing due to multiple overrides.

### Case 1

Previously, this input:

```css
.test {
    text-align: left;
    text-align: center;
}
```

Was converted to:

```css
[dir="ltr"] .test {
    text-align: left;
}

[dir="rtl"] .test {
    text-align: right;
}

[dir] .test {
    text-align: center;
}
```

But there is no need to convert that input, the `text-align` property has been overridden by a property that doesn‘t have an `rtl` counterpart, so it should not be modified.

### Case 2

Previously, this input:

```css
.test1 {
    padding-right: 8px;
    padding-left: 8px;
    padding-left: 0;
    padding-right: 0;
}
```

Was converted to:

```css
.test1 {
    padding-left: 0;
    padding-right: 0;
}

[dir="ltr"] .test1 {
    padding-right: 8px;
    padding-left: 8px;
}

[dir="rtl"] .test1 {
    padding-left: 8px;
    padding-right: 8px;
}
```

So, the paddings with value `0` have been overridden by the paddings with value `8px` and it should be in the other way around. On the other hand, if this input is flipped, the same result is obtained, so there is no need to change this input either because it is symmetrical.