### PR TITLE
Upgrade RTLCSS to major version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.0.0] - 2022-09-15
+
+- Upgrade RTLCSS to major version 4.0.0. This version brings these changes:
+    * Support flipping `justify-content`, `justify-items` and `justify-self`
+    * Support flipping length background position without using `calc`
+- Update dependencies
+
 ## [3.7.2] - 2022-07-24
 
 - Fix a Vite 3 warning

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ All the options are optional, and a default value will be used if any of them is
 | processUrls        | `boolean`                 | `false`         | Change the strings in URLs using the string map         |
 | processKeyFrames   | `boolean`                 | `false`         | Flip keyframe animations                                     |
 | processEnv         | `boolean`                 | `true`          | When processEnv is false, it prevents flipping agent-defined environment variables (`safe-area-inset-left` and `safe-area-inset-right`) |
-| useCalc            | `boolean`                 | `false`         | Flips `background-position`, `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) |
+| useCalc            | `boolean`                 | `false`         | Flips `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) |
 | stringMap          | `PluginStringMap[]`       | Check below     | An array of strings maps that will be used to make the replacements of the URLs and rules selectors names |
 | autoRename         | `Autorename (string)`     | `Autorename.disabled` | Flip or not the selectors names of the rules without directional properties using the `stringMap` |
 | greedy             | `boolean`                 | `false`         | When `autoRename` is enabled and greedy is `true`, the strings replacements will not take into account word boundaries |
@@ -1119,7 +1119,7 @@ const options = { processEnv: false };
 <details><summary>Expand</summary>
 <p>
 
-When this option is enabled, it flips `background-position`, `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc):
+When this option is enabled, it flips `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc):
 
 ##### input
 

--- a/package.json
+++ b/package.json
@@ -52,30 +52,30 @@
     "url": "git+https://github.com/elchininet/postcss-rtlcss"
   },
   "dependencies": {
-    "rtlcss": "^3.5.0"
+    "rtlcss": "4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
-    "@types/eslint": "^8.4.5",
-    "@types/jest": "^28.1.4",
-    "@types/node": "^18.0.0",
+    "@types/eslint": "^8.4.6",
+    "@types/jest": "^29.0.2",
+    "@types/node": "^18.7.18",
     "@types/rtlcss": "^3.5.0",
-    "@typescript-eslint/eslint-plugin": "^5.30.3",
-    "@typescript-eslint/parser": "^5.30.3",
+    "@typescript-eslint/eslint-plugin": "^5.37.0",
+    "@typescript-eslint/parser": "^5.37.0",
     "coveralls": "^3.1.1",
-    "eslint": "^8.19.0",
-    "eslint-plugin-jest": "^26.5.3",
-    "jest": "^28.1.2",
-    "postcss": "^8.3.11",
+    "eslint": "^8.23.1",
+    "eslint-plugin-jest": "^27.0.4",
+    "jest": "^29.0.3",
+    "postcss": "^8.4.16",
     "replace-in-file": "^6.3.5",
-    "rollup": "^2.75.7",
+    "rollup": "^2.79.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-ts": "^3.0.2",
-    "ts-jest": "^28.0.5",
-    "typescript": "^4.7.4"
+    "ts-jest": "^29.0.1",
+    "typescript": "^4.8.3"
   },
   "peerDependencies": {
-    "postcss": "^8.0.0"
+    "postcss": "^8.4.6"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/tests/__snapshots__/autorename.test.ts.snap
+++ b/tests/__snapshots__/autorename.test.ts.snap
@@ -2,21 +2,22 @@
 
 exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -37,11 +38,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -52,12 +53,12 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -70,9 +71,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -80,9 +81,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -96,11 +97,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -108,22 +109,22 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -131,9 +132,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -156,11 +157,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -182,11 +183,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -198,11 +199,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -221,11 +222,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -273,12 +274,12 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -294,11 +295,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -315,19 +316,19 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -344,11 +345,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -356,23 +357,23 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -381,35 +382,35 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -418,13 +419,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -435,13 +436,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -452,13 +453,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -468,11 +469,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -481,11 +482,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -493,23 +494,23 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -550,11 +551,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -568,11 +569,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -581,11 +582,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -593,19 +594,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -616,21 +617,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -651,11 +653,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -666,12 +668,12 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -684,9 +686,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -694,9 +696,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -710,11 +712,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -722,22 +724,22 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -745,9 +747,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -770,11 +772,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -796,11 +798,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -812,11 +814,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -835,11 +837,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -887,12 +889,12 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -908,11 +910,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -929,19 +931,19 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -958,11 +960,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -970,23 +972,23 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -995,35 +997,35 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1032,13 +1034,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1049,13 +1051,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -1066,13 +1068,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1082,11 +1084,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -1095,11 +1097,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -1107,23 +1109,23 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1164,11 +1166,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -1182,11 +1184,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -1195,11 +1197,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible with custom string map 1
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -1207,19 +1209,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1230,21 +1232,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1265,11 +1268,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -1280,12 +1283,12 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -1298,9 +1301,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -1308,9 +1311,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -1324,11 +1327,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -1336,22 +1339,22 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -1359,9 +1362,9 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -1384,11 +1387,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -1410,11 +1413,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -1426,11 +1429,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -1449,11 +1452,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -1501,12 +1504,12 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -1522,11 +1525,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -1543,19 +1546,19 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -1572,11 +1575,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -1584,23 +1587,23 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1609,35 +1612,35 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1646,13 +1649,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1663,13 +1666,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -1680,13 +1683,13 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1696,11 +1699,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -1709,11 +1712,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -1721,23 +1724,23 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1778,11 +1781,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -1796,11 +1799,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -1809,11 +1812,11 @@ exports[`[[Mode: combined]] Autorename Tests:  flexible, greedy: true 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -1821,19 +1824,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1844,21 +1847,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1879,11 +1883,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -1894,12 +1898,12 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -1912,9 +1916,9 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -1922,9 +1926,9 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -1938,11 +1942,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -1950,22 +1954,22 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -1973,9 +1977,9 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -1998,11 +2002,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -2024,11 +2028,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -2040,11 +2044,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -2063,11 +2067,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -2115,12 +2119,12 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -2136,11 +2140,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -2157,19 +2161,19 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2186,11 +2190,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2198,23 +2202,23 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2223,35 +2227,35 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -2260,13 +2264,13 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2277,13 +2281,13 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -2294,13 +2298,13 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2310,11 +2314,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -2323,11 +2327,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -2335,23 +2339,23 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -2392,11 +2396,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -2410,11 +2414,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -2423,11 +2427,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -2435,19 +2439,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -2458,21 +2462,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -2493,11 +2498,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -2508,12 +2513,12 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -2526,9 +2531,9 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -2536,9 +2541,9 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -2552,11 +2557,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -2564,22 +2569,22 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -2587,9 +2592,9 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2612,11 +2617,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -2638,11 +2643,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -2654,11 +2659,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -2677,11 +2682,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -2729,12 +2734,12 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -2750,11 +2755,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -2771,19 +2776,19 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2800,11 +2805,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2812,23 +2817,23 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2837,35 +2842,35 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -2874,13 +2879,13 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2891,13 +2896,13 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -2908,13 +2913,13 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2924,11 +2929,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -2937,11 +2942,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -2949,23 +2954,23 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -3006,11 +3011,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -3024,11 +3029,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -3037,11 +3042,11 @@ exports[`[[Mode: combined]] Autorename Tests:  only control directives, greedy: 
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -3049,19 +3054,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -3072,21 +3077,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -3107,11 +3113,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -3122,12 +3128,12 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -3140,9 +3146,9 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -3150,9 +3156,9 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -3166,11 +3172,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -3178,22 +3184,22 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -3201,9 +3207,9 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3226,11 +3232,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -3252,11 +3258,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -3268,11 +3274,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -3291,11 +3297,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -3343,12 +3349,12 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -3364,11 +3370,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -3385,19 +3391,19 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -3414,11 +3420,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -3426,23 +3432,23 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -3451,35 +3457,35 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -3488,13 +3494,13 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -3505,13 +3511,13 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -3522,13 +3528,13 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -3538,11 +3544,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -3551,11 +3557,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -3563,23 +3569,23 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -3620,11 +3626,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -3638,11 +3644,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -3651,11 +3657,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -3663,19 +3669,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -3686,21 +3692,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -3721,11 +3728,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -3736,12 +3743,12 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -3754,9 +3761,9 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -3764,9 +3771,9 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -3780,11 +3787,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -3792,22 +3799,22 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -3815,9 +3822,9 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3840,11 +3847,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -3866,11 +3873,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -3882,11 +3889,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -3905,11 +3912,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -3957,12 +3964,12 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -3978,11 +3985,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -3999,19 +4006,19 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -4028,11 +4035,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -4040,23 +4047,23 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -4065,35 +4072,35 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -4102,13 +4109,13 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -4119,13 +4126,13 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -4136,13 +4143,13 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -4152,11 +4159,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -4165,11 +4172,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -4177,23 +4184,23 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -4234,11 +4241,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -4252,11 +4259,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -4265,11 +4272,11 @@ exports[`[[Mode: combined]] Autorename Tests:  strict, greedy: true 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -4277,19 +4284,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -4300,6 +4307,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: diff]] Autorename Tests:  flexible 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4341,7 +4349,7 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4386,27 +4394,27 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4504,6 +4512,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Autorename Tests:  flexible with custom string map 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4545,7 +4554,7 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible with custom string map 1`] =
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4590,35 +4599,35 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible with custom string map 1`] =
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4716,6 +4725,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Autorename Tests:  flexible, greedy: true 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4757,7 +4767,7 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible, greedy: true 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4802,35 +4812,35 @@ exports[`[[Mode: diff]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4928,6 +4938,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Autorename Tests:  only control directives 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4969,7 +4980,7 @@ exports[`[[Mode: diff]] Autorename Tests:  only control directives 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5007,19 +5018,19 @@ exports[`[[Mode: diff]] Autorename Tests:  only control directives 1`] = `
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5117,6 +5128,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Autorename Tests:  only control directives, greedy: true 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5158,7 +5170,7 @@ exports[`[[Mode: diff]] Autorename Tests:  only control directives, greedy: true
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5196,23 +5208,23 @@ exports[`[[Mode: diff]] Autorename Tests:  only control directives, greedy: true
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5310,6 +5322,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Autorename Tests:  strict 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5351,7 +5364,7 @@ exports[`[[Mode: diff]] Autorename Tests:  strict 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5389,27 +5402,27 @@ exports[`[[Mode: diff]] Autorename Tests:  strict 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5507,6 +5520,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Autorename Tests:  strict, greedy: true 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5548,7 +5562,7 @@ exports[`[[Mode: diff]] Autorename Tests:  strict, greedy: true 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5586,35 +5600,35 @@ exports[`[[Mode: diff]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5712,7 +5726,7 @@ html .test50 {
 
 exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -5723,7 +5737,8 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5746,7 +5761,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -5759,7 +5774,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -5777,9 +5792,9 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -5795,7 +5810,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -5807,7 +5822,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -5824,9 +5839,9 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5853,7 +5868,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -5877,7 +5892,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -5890,7 +5905,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -5911,7 +5926,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -5964,7 +5979,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -5981,7 +5996,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -5998,19 +6013,19 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -6027,11 +6042,11 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -6039,31 +6054,31 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -6071,20 +6086,20 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -6096,7 +6111,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6111,13 +6126,13 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -6129,12 +6144,12 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -6144,7 +6159,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -6155,7 +6170,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -6165,20 +6180,20 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -6220,7 +6235,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -6235,7 +6250,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -6248,7 +6263,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -6257,7 +6272,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -6266,7 +6281,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -6278,7 +6293,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -6289,7 +6304,8 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -6312,7 +6328,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -6325,7 +6341,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -6343,9 +6359,9 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -6361,7 +6377,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -6373,7 +6389,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -6390,9 +6406,9 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -6419,7 +6435,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -6443,7 +6459,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -6456,7 +6472,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -6477,7 +6493,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -6530,7 +6546,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -6547,7 +6563,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -6564,19 +6580,19 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -6593,11 +6609,11 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -6605,31 +6621,31 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -6637,20 +6653,20 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -6662,7 +6678,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6677,13 +6693,13 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -6695,12 +6711,12 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -6710,7 +6726,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -6721,7 +6737,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -6731,20 +6747,20 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -6786,7 +6802,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -6801,7 +6817,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -6814,7 +6830,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible with custom string map 1
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -6823,7 +6839,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -6832,7 +6848,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -6844,7 +6860,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -6855,7 +6871,8 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -6878,7 +6895,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -6891,7 +6908,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -6909,9 +6926,9 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -6927,7 +6944,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -6939,7 +6956,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -6956,9 +6973,9 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -6985,7 +7002,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -7009,7 +7026,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -7022,7 +7039,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -7043,7 +7060,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -7096,7 +7113,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -7113,7 +7130,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -7130,19 +7147,19 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -7159,11 +7176,11 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -7171,31 +7188,31 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -7203,20 +7220,20 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -7228,7 +7245,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -7243,13 +7260,13 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -7261,12 +7278,12 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -7276,7 +7293,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -7287,7 +7304,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -7297,20 +7314,20 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -7352,7 +7369,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -7367,7 +7384,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -7380,7 +7397,7 @@ exports[`[[Mode: override]] Autorename Tests:  flexible, greedy: true 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -7389,7 +7406,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -7398,7 +7415,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -7410,7 +7427,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -7421,7 +7438,8 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -7444,7 +7462,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -7457,7 +7475,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -7475,9 +7493,9 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -7493,7 +7511,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -7505,7 +7523,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -7522,9 +7540,9 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -7551,7 +7569,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -7575,7 +7593,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -7588,7 +7606,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -7609,7 +7627,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -7662,7 +7680,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -7679,7 +7697,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -7696,19 +7714,19 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -7725,11 +7743,11 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -7737,31 +7755,31 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -7769,20 +7787,20 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -7794,7 +7812,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -7809,13 +7827,13 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -7827,12 +7845,12 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -7842,7 +7860,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -7853,7 +7871,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -7863,20 +7881,20 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -7918,7 +7936,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -7933,7 +7951,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -7946,7 +7964,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -7955,7 +7973,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -7964,7 +7982,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -7976,7 +7994,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -7987,7 +8005,8 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -8010,7 +8029,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -8023,7 +8042,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -8041,9 +8060,9 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -8059,7 +8078,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -8071,7 +8090,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -8088,9 +8107,9 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -8117,7 +8136,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -8141,7 +8160,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -8154,7 +8173,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -8175,7 +8194,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -8228,7 +8247,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -8245,7 +8264,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -8262,19 +8281,19 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -8291,11 +8310,11 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -8303,31 +8322,31 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -8335,20 +8354,20 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -8360,7 +8379,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -8375,13 +8394,13 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -8393,12 +8412,12 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -8408,7 +8427,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -8419,7 +8438,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -8429,20 +8448,20 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -8484,7 +8503,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -8499,7 +8518,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -8512,7 +8531,7 @@ exports[`[[Mode: override]] Autorename Tests:  only control directives, greedy: 
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -8521,7 +8540,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -8530,7 +8549,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -8542,7 +8561,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -8553,7 +8572,8 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -8576,7 +8596,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -8589,7 +8609,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -8607,9 +8627,9 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -8625,7 +8645,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -8637,7 +8657,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -8654,9 +8674,9 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -8683,7 +8703,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -8707,7 +8727,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -8720,7 +8740,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -8741,7 +8761,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -8794,7 +8814,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -8811,7 +8831,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -8828,19 +8848,19 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -8857,11 +8877,11 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -8869,31 +8889,31 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -8901,20 +8921,20 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -8926,7 +8946,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -8941,13 +8961,13 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -8959,12 +8979,12 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -8974,7 +8994,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -8985,7 +9005,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -8995,20 +9015,20 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -9050,7 +9070,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -9065,7 +9085,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -9078,7 +9098,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -9087,7 +9107,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -9096,7 +9116,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -9108,7 +9128,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -9119,7 +9139,8 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -9142,7 +9163,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -9155,7 +9176,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -9173,9 +9194,9 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -9191,7 +9212,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -9203,7 +9224,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -9220,9 +9241,9 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -9249,7 +9270,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -9273,7 +9294,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -9286,7 +9307,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -9307,7 +9328,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -9360,7 +9381,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -9377,7 +9398,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -9394,19 +9415,19 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 .test25, .test26-rtl, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -9423,11 +9444,11 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 .test28-right::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -9435,31 +9456,31 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -9467,20 +9488,20 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -9492,7 +9513,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -9507,13 +9528,13 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -9525,12 +9546,12 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -9540,7 +9561,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -9551,7 +9572,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -9561,20 +9582,20 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -9616,7 +9637,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -9631,7 +9652,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -9644,7 +9665,7 @@ exports[`[[Mode: override]] Autorename Tests:  strict, greedy: true 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -9653,7 +9674,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -9662,7 +9683,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options.test.ts.snap
+++ b/tests/__snapshots__/basic-options.test.ts.snap
@@ -2,21 +2,22 @@
 
 exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -37,11 +38,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -52,12 +53,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -70,9 +71,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -80,9 +81,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -96,11 +97,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -108,22 +109,22 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -131,9 +132,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -156,11 +157,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -180,13 +181,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     animation: 5s flip-ltr 1s ease-in-out,
                3s my-animation-ltr 6s ease-in-out;
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     animation: 5s flip-rtl 1s ease-in-out,
                3s my-animation-rtl 6s ease-in-out;
     padding: 10px 10px 40px 20px;
@@ -200,11 +201,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -233,11 +234,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -248,11 +249,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     animation-timing-function: ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test19 {
+[dir="ltr"] .test19 {
     animation-name: my-animation-ltr;
 }
 
-[dir=\\"rtl\\"] .test19 {
+[dir="rtl"] .test19 {
     animation-name: my-animation-rtl;
 }
 
@@ -262,11 +263,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     animation-timing-function: ease;
 }
 
-[dir=\\"ltr\\"] .test20 {
+[dir="ltr"] .test20 {
     animation-name: my-animation-ltr, no-flip;
 }
 
-[dir=\\"rtl\\"] .test20 {
+[dir="rtl"] .test20 {
     animation-name: my-animation-rtl, no-flip;
 }
 
@@ -309,12 +310,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -330,11 +331,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -351,19 +352,19 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -380,11 +381,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -392,23 +393,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -417,35 +418,35 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -454,13 +455,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -471,13 +472,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -488,13 +489,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -504,11 +505,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -517,11 +518,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -529,23 +530,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -573,11 +574,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     }
 }
 
-[dir=\\"ltr\\"] .test44 {
+[dir="ltr"] .test44 {
     animation: 5s normalFlip-ltr 1s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test44 {
+[dir="rtl"] .test44 {
     animation: 5s normalFlip-rtl 1s ease-in-out;
 }
 
@@ -605,11 +606,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     }
 }
 
-[dir=\\"ltr\\"] .test45 {
+[dir="ltr"] .test45 {
     animation: 5s inversedFlip-ltr 1s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test45 {
+[dir="rtl"] .test45 {
     animation: 5s inversedFlip-rtl 1s ease-in-out;
 }
 
@@ -618,11 +619,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -636,11 +637,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -649,11 +650,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -661,19 +662,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -688,16 +689,18 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -706,7 +709,6 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -723,11 +725,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -738,12 +740,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -756,9 +758,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -766,9 +768,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -782,11 +784,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -794,22 +796,22 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -817,9 +819,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -842,11 +844,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -868,11 +870,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -884,11 +886,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -907,11 +909,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -959,12 +961,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -980,11 +982,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -1001,19 +1003,19 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -1030,11 +1032,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -1042,23 +1044,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1067,35 +1069,35 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1104,13 +1106,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1121,13 +1123,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -1138,13 +1140,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1154,11 +1156,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -1167,11 +1169,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -1179,23 +1181,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1236,11 +1238,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -1254,11 +1256,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -1267,11 +1269,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -1279,19 +1281,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1302,21 +1304,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1337,11 +1340,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: rtl;
 }
 
@@ -1352,12 +1355,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -1370,9 +1373,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     position: absolute;
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -1380,9 +1383,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -1396,11 +1399,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -1408,22 +1411,22 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -1431,9 +1434,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -1456,11 +1459,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -1480,13 +1483,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     font-size: 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     animation: 5s flip-rtl 1s ease-in-out,
                3s my-animation-rtl 6s ease-in-out;
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     animation: 5s flip-ltr 1s ease-in-out,
                3s my-animation-ltr 6s ease-in-out;
     padding: 10px 10px 40px 20px;
@@ -1500,11 +1503,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     right: 10px;
 }
 
@@ -1533,11 +1536,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -1548,11 +1551,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     animation-timing-function: ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test19 {
+[dir="rtl"] .test19 {
     animation-name: my-animation-rtl;
 }
 
-[dir=\\"ltr\\"] .test19 {
+[dir="ltr"] .test19 {
     animation-name: my-animation-ltr;
 }
 
@@ -1562,11 +1565,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     animation-timing-function: ease;
 }
 
-[dir=\\"rtl\\"] .test20 {
+[dir="rtl"] .test20 {
     animation-name: my-animation-rtl, no-flip;
 }
 
-[dir=\\"ltr\\"] .test20 {
+[dir="ltr"] .test20 {
     animation-name: my-animation-ltr, no-flip;
 }
 
@@ -1609,12 +1612,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -1630,11 +1633,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #000;
 }
 
@@ -1651,19 +1654,19 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -1680,11 +1683,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -1692,23 +1695,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1717,35 +1720,35 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .example34 {
+[dir="ltr"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .example35 {
+[dir="ltr"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1754,13 +1757,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -1771,13 +1774,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -1788,13 +1791,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -1804,11 +1807,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 50%;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
@@ -1817,11 +1820,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
@@ -1829,23 +1832,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     color: #EFEFEF;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1873,11 +1876,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     }
 }
 
-[dir=\\"rtl\\"] .test44 {
+[dir="rtl"] .test44 {
     animation: 5s normalFlip-rtl 1s ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test44 {
+[dir="ltr"] .test44 {
     animation: 5s normalFlip-ltr 1s ease-in-out;
 }
 
@@ -1905,11 +1908,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     }
 }
 
-[dir=\\"rtl\\"] .test45 {
+[dir="rtl"] .test45 {
     animation: 5s inversedFlip-rtl 1s ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test45 {
+[dir="ltr"] .test45 {
     animation: 5s inversedFlip-ltr 1s ease-in-out;
 }
 
@@ -1918,11 +1921,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
         cursor: wait;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
@@ -1936,11 +1939,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
         cursor: wait;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -1949,11 +1952,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     }
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -1961,19 +1964,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1984,21 +1987,22 @@ html[dir=\\"ltr\\"] .test50 {
 
 exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -2019,11 +2023,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: rtl;
 }
 
@@ -2034,12 +2038,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -2052,9 +2056,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     position: absolute;
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -2062,9 +2066,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -2078,11 +2082,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -2090,22 +2094,22 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -2113,9 +2117,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2138,11 +2142,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -2164,11 +2168,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -2180,11 +2184,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     right: 10px;
 }
 
@@ -2203,11 +2207,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -2255,12 +2259,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -2276,11 +2280,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #000;
 }
 
@@ -2297,19 +2301,19 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2326,11 +2330,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2338,23 +2342,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2363,35 +2367,35 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .example34 {
+[dir="ltr"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .example35 {
+[dir="ltr"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -2400,13 +2404,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -2417,13 +2421,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -2434,13 +2438,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -2450,11 +2454,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 50%;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
@@ -2463,11 +2467,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
@@ -2475,23 +2479,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -2532,11 +2536,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
@@ -2550,11 +2554,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -2563,11 +2567,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -2575,19 +2579,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -2598,13 +2602,13 @@ html[dir=\\"ltr\\"] .test50 {
 
 exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
@@ -2612,8 +2616,8 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background-position: calc(100% - 10px) 20px;
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -2634,11 +2638,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -2648,13 +2652,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
     transform-origin: 10px 20px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
     transform-origin: calc(100% - 10px) 20px;
@@ -2668,9 +2672,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -2678,9 +2682,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -2694,11 +2698,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -2706,22 +2710,22 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -2729,9 +2733,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2754,11 +2758,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -2780,11 +2784,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -2796,11 +2800,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -2819,11 +2823,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -2871,12 +2875,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -2892,11 +2896,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -2913,19 +2917,19 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2942,11 +2946,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2954,23 +2958,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2979,35 +2983,35 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -3016,13 +3020,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -3033,13 +3037,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -3050,13 +3054,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -3066,11 +3070,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -3079,11 +3083,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -3091,23 +3095,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -3148,11 +3152,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -3166,11 +3170,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -3179,11 +3183,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -3191,19 +3195,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -3214,21 +3218,22 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -3249,11 +3254,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -3264,12 +3269,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -3282,9 +3287,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -3292,9 +3297,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -3308,11 +3313,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -3320,22 +3325,22 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -3343,9 +3348,9 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3368,11 +3373,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -3394,11 +3399,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -3410,11 +3415,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -3433,11 +3438,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -3485,12 +3490,12 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -3506,11 +3511,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -3527,19 +3532,19 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -3556,11 +3561,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -3568,23 +3573,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -3593,35 +3598,35 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -3630,13 +3635,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -3647,13 +3652,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -3664,13 +3669,13 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -3680,11 +3685,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -3693,11 +3698,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -3705,23 +3710,23 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -3762,11 +3767,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -3780,11 +3785,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -3793,11 +3798,11 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -3805,19 +3810,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -3828,6 +3833,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: diff]] Basic Options Tests:  {processKeyFrames: true} 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3869,7 +3875,7 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processKeyFrames: true} 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3937,19 +3943,19 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processKeyFrames: true} 1`] = `
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4079,9 +4085,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] Basic Options Tests:  {processUrls: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4123,7 +4129,7 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processUrls: true} 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4161,19 +4167,19 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4271,6 +4277,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl, processKeyFrames: true} 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4312,7 +4319,7 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl, processKeyFrames: tr
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4380,19 +4387,19 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl, processKeyFrames: tr
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4522,6 +4529,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl} 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4563,7 +4571,7 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl} 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4601,19 +4609,19 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4711,7 +4719,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Basic Options Tests:  {useCalc: true} 1`] = `
 ".test1, .test2 {
-    background-position: calc(100% - 10px) 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4754,7 +4762,7 @@ exports[`[[Mode: diff]] Basic Options Tests:  {useCalc: true} 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4792,19 +4800,19 @@ exports[`[[Mode: diff]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4902,6 +4910,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Basic Options Tests:  Basic 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4943,7 +4952,7 @@ exports[`[[Mode: diff]] Basic Options Tests:  Basic 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4981,19 +4990,19 @@ exports[`[[Mode: diff]] Basic Options Tests:  Basic 1`] = `
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5091,7 +5100,7 @@ html .test50 {
 
 exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -5102,7 +5111,8 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5125,7 +5135,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -5138,7 +5148,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -5156,9 +5166,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -5174,7 +5184,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -5186,7 +5196,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -5203,9 +5213,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5232,7 +5242,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -5256,7 +5266,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     animation: 5s flip-rtl 1s ease-in-out,
                3s my-animation-rtl 6s ease-in-out;
     padding: 10px 10px 40px 20px;
@@ -5271,7 +5281,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -5302,7 +5312,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -5314,7 +5324,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     animation-timing-function: ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test19 {
+[dir="rtl"] .test19 {
     animation-name: my-animation-rtl;
 }
 
@@ -5325,7 +5335,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     animation-timing-function: ease;
 }
 
-[dir=\\"rtl\\"] .test20 {
+[dir="rtl"] .test20 {
     animation-name: my-animation-rtl, no-flip;
 }
 
@@ -5373,7 +5383,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -5390,7 +5400,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -5407,19 +5417,19 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -5436,11 +5446,11 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -5448,31 +5458,31 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5480,20 +5490,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -5505,7 +5515,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -5520,13 +5530,13 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -5538,12 +5548,12 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -5553,7 +5563,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -5564,7 +5574,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -5574,20 +5584,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -5619,7 +5629,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     animation: 5s normalFlip-ltr 1s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test44 {
+[dir="rtl"] .test44 {
     animation: 5s normalFlip-rtl 1s ease-in-out;
 }
 
@@ -5651,7 +5661,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     animation: 5s inversedFlip-rtl 1s ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test45 {
+[dir="ltr"] .test45 {
     animation: 5s inversedFlip-ltr 1s ease-in-out;
 }
 
@@ -5661,7 +5671,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -5676,7 +5686,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -5689,7 +5699,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -5698,7 +5708,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -5707,7 +5717,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -5719,7 +5729,8 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     color: #666;
     padding-right: 20px;
@@ -5728,8 +5739,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5739,7 +5751,6 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -5757,7 +5768,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -5770,7 +5781,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -5788,9 +5799,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -5806,7 +5817,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -5818,7 +5829,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -5835,9 +5846,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5864,7 +5875,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -5888,7 +5899,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -5901,7 +5912,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -5922,7 +5933,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -5975,7 +5986,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -5992,7 +6003,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -6009,19 +6020,19 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -6038,11 +6049,11 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -6050,31 +6061,31 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -6082,20 +6093,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -6107,7 +6118,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6122,13 +6133,13 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -6140,12 +6151,12 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -6155,7 +6166,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -6166,7 +6177,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -6176,20 +6187,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -6231,7 +6242,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -6246,7 +6257,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -6259,7 +6270,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -6268,7 +6279,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -6277,7 +6288,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -6289,7 +6300,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -6300,7 +6311,8 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -6323,7 +6335,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: rtl;
 }
 
@@ -6336,7 +6348,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -6354,9 +6366,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -6372,7 +6384,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -6384,7 +6396,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -6401,9 +6413,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -6430,7 +6442,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding-right: 20px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -6454,7 +6466,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     animation: 5s flip-ltr 1s ease-in-out,
                3s my-animation-ltr 6s ease-in-out;
     padding: 10px 10px 40px 20px;
@@ -6469,7 +6481,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -6500,7 +6512,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -6512,7 +6524,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     animation-timing-function: ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test19 {
+[dir="ltr"] .test19 {
     animation-name: my-animation-ltr;
 }
 
@@ -6523,7 +6535,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     animation-timing-function: ease;
 }
 
-[dir=\\"ltr\\"] .test20 {
+[dir="ltr"] .test20 {
     animation-name: my-animation-ltr, no-flip;
 }
 
@@ -6571,7 +6583,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -6588,7 +6600,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #000;
 }
 
@@ -6605,19 +6617,19 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -6634,11 +6646,11 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -6646,31 +6658,31 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -6678,20 +6690,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .example34 {
+[dir="ltr"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .example35 {
+[dir="ltr"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -6703,7 +6715,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6718,7 +6730,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6733,7 +6745,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6745,7 +6757,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -6756,7 +6768,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -6766,20 +6778,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -6811,7 +6823,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     animation: 5s normalFlip-ltr 1s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test44 {
+[dir="rtl"] .test44 {
     animation: 5s normalFlip-rtl 1s ease-in-out;
 }
 
@@ -6843,7 +6855,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     animation: 5s inversedFlip-rtl 1s ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test45 {
+[dir="ltr"] .test45 {
     animation: 5s inversedFlip-ltr 1s ease-in-out;
 }
 
@@ -6853,7 +6865,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -6868,7 +6880,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -6881,7 +6893,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -6890,7 +6902,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -6899,7 +6911,7 @@ html[dir=\\"ltr\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -6911,7 +6923,7 @@ html[dir=\\"ltr\\"] .test50 {
 
 exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -6922,7 +6934,8 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -6945,7 +6958,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: rtl;
 }
 
@@ -6958,7 +6971,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -6976,9 +6989,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -6994,7 +7007,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -7006,7 +7019,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -7023,9 +7036,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -7052,7 +7065,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -7076,7 +7089,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -7089,7 +7102,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -7110,7 +7123,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -7163,7 +7176,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -7180,7 +7193,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #000;
 }
 
@@ -7197,19 +7210,19 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -7226,11 +7239,11 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -7238,31 +7251,31 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -7270,20 +7283,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .example34 {
+[dir="ltr"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .example35 {
+[dir="ltr"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -7295,7 +7308,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -7310,7 +7323,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -7325,7 +7338,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -7337,7 +7350,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -7348,7 +7361,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -7358,20 +7371,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -7413,7 +7426,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -7428,7 +7441,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -7441,7 +7454,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -7450,7 +7463,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -7459,7 +7472,7 @@ html[dir=\\"ltr\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -7471,7 +7484,7 @@ html[dir=\\"ltr\\"] .test50 {
 
 exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -7482,8 +7495,8 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background-position: calc(100% - 10px) 20px;
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -7506,7 +7519,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -7519,7 +7532,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
     transform-origin: calc(100% - 10px) 20px;
@@ -7538,9 +7551,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -7556,7 +7569,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -7568,7 +7581,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -7585,9 +7598,9 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -7614,7 +7627,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -7638,7 +7651,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -7651,7 +7664,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -7672,7 +7685,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -7725,7 +7738,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -7742,7 +7755,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -7759,19 +7772,19 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -7788,11 +7801,11 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -7800,31 +7813,31 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -7832,20 +7845,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -7857,7 +7870,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -7872,13 +7885,13 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -7890,12 +7903,12 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -7905,7 +7918,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -7916,7 +7929,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -7926,20 +7939,20 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -7981,7 +7994,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -7996,7 +8009,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -8009,7 +8022,7 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -8018,7 +8031,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -8027,7 +8040,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -8039,7 +8052,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -8050,7 +8063,8 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -8073,7 +8087,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -8086,7 +8100,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -8104,9 +8118,9 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -8122,7 +8136,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -8134,7 +8148,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -8151,9 +8165,9 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -8180,7 +8194,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -8204,7 +8218,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -8217,7 +8231,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -8238,7 +8252,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -8291,7 +8305,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -8308,7 +8322,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -8325,19 +8339,19 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -8354,11 +8368,11 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -8366,31 +8380,31 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -8398,20 +8412,20 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -8423,7 +8437,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -8438,13 +8452,13 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -8456,12 +8470,12 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -8471,7 +8485,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -8482,7 +8496,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -8492,20 +8506,20 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -8547,7 +8561,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -8562,7 +8576,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -8575,7 +8589,7 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -8584,7 +8598,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -8593,7 +8607,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }

--- a/tests/__snapshots__/nested-rules.test.ts.snap
+++ b/tests/__snapshots__/nested-rules.test.ts.snap
@@ -10,7 +10,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test1 {
+[dir="ltr"] .test1 {
     left: 10px;
 
     .test2 {
@@ -18,7 +18,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test1 {
+[dir="rtl"] .test1 {
     right: 10px;
 
     .test2 {
@@ -36,7 +36,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     left: 10px;
 
     &.test4 {
@@ -50,7 +50,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     right: 10px;
 
     &.test4 {
@@ -80,14 +80,14 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
             background-color: #FFF;
 
             ::after {
-                content: \\"\\";
+                content: "";
                 display: block;
             }
         }
     }
 }
 
-[dir=\\"ltr\\"] .test6 {
+[dir="ltr"] .test6 {
     .global & {
         padding: 5px 10px 5px 5px;
         border-left-color: #666;
@@ -106,7 +106,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test6 {
+[dir="rtl"] .test6 {
     .global & {
         padding: 5px 5px 5px 10px;
         border-right-color: #666;
@@ -130,22 +130,22 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
         color: red;
     }
 
-    [dir=\\"ltr\\"] .test8 {
+    [dir="ltr"] .test8 {
         left: 10px;
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test8 {
+    [dir="rtl"] .test8 {
         right: 10px;
         text-align: right;
     }
 
     @media screen and (max-width: 800px) {
-        [dir=\\"ltr\\"] .test9 {
+        [dir="ltr"] .test9 {
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"rtl\\"] .test9 {
+        [dir="rtl"] .test9 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -153,11 +153,11 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
 
 @media screen and (max-width: 800px) {
     @supports (display: contents) and (display: grid) {
-        [dir=\\"ltr\\"] .test10 {
+        [dir="ltr"] .test10 {
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"rtl\\"] .test10 {
+        [dir="rtl"] .test10 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -171,13 +171,13 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test11 {
+[dir="ltr"] .test11 {
     .test13 {
         text-align: right;
     }
 }
 
-[dir=\\"rtl\\"] .test11 {
+[dir="rtl"] .test11 {
     .test13 {
         text-align: left;
     }
@@ -194,7 +194,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test1 {
+[dir="rtl"] .test1 {
     left: 10px;
 
     .test2 {
@@ -202,7 +202,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test1 {
+[dir="ltr"] .test1 {
     right: 10px;
 
     .test2 {
@@ -220,7 +220,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     left: 10px;
 
     &.test4 {
@@ -234,7 +234,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     right: 10px;
 
     &.test4 {
@@ -264,14 +264,14 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
             background-color: #FFF;
 
             ::after {
-                content: \\"\\";
+                content: "";
                 display: block;
             }
         }
     }
 }
 
-[dir=\\"rtl\\"] .test6 {
+[dir="rtl"] .test6 {
     .global & {
         padding: 5px 10px 5px 5px;
         border-left-color: #666;
@@ -290,7 +290,7 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test6 {
+[dir="ltr"] .test6 {
     .global & {
         padding: 5px 5px 5px 10px;
         border-right-color: #666;
@@ -314,22 +314,22 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
         color: red;
     }
 
-    [dir=\\"rtl\\"] .test8 {
+    [dir="rtl"] .test8 {
         left: 10px;
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test8 {
+    [dir="ltr"] .test8 {
         right: 10px;
         text-align: right;
     }
 
     @media screen and (max-width: 800px) {
-        [dir=\\"rtl\\"] .test9 {
+        [dir="rtl"] .test9 {
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"ltr\\"] .test9 {
+        [dir="ltr"] .test9 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -337,11 +337,11 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
 
 @media screen and (max-width: 800px) {
     @supports (display: contents) and (display: grid) {
-        [dir=\\"rtl\\"] .test10 {
+        [dir="rtl"] .test10 {
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"ltr\\"] .test10 {
+        [dir="ltr"] .test10 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -355,13 +355,13 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test11 {
+[dir="rtl"] .test11 {
     .test13 {
         text-align: right;
     }
 }
 
-[dir=\\"ltr\\"] .test11 {
+[dir="ltr"] .test11 {
     .test13 {
         text-align: left;
     }
@@ -532,7 +532,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test1 {
+[dir="rtl"] .test1 {
     left: auto;
     right: 10px;
 
@@ -558,7 +558,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     left: auto;
     right: 10px;
 
@@ -593,7 +593,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
             background-color: #FFF;
 
             ::after {
-                content: \\"\\";
+                content: "";
                 display: block;
                 text-align: left;
             }
@@ -601,7 +601,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test6 {
+[dir="rtl"] .test6 {
     .global & {
         padding: 5px 5px 5px 10px;
         border-left-color: currentcolor;
@@ -629,7 +629,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test8 {
+    [dir="rtl"] .test8 {
         left: auto;
         right: 10px;
         text-align: right;
@@ -640,7 +640,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"rtl\\"] .test9 {
+        [dir="rtl"] .test9 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -652,7 +652,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"rtl\\"] .test10 {
+        [dir="rtl"] .test10 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -670,7 +670,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
     }
 }
 
-[dir=\\"rtl\\"] .test11 {
+[dir="rtl"] .test11 {
     .test13 {
         text-align: left;
     }
@@ -689,7 +689,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test1 {
+[dir="ltr"] .test1 {
     left: auto;
     right: 10px;
 
@@ -715,7 +715,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     left: auto;
     right: 10px;
 
@@ -750,7 +750,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
             background-color: #FFF;
 
             ::after {
-                content: \\"\\";
+                content: "";
                 display: block;
                 text-align: left;
             }
@@ -758,7 +758,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test6 {
+[dir="ltr"] .test6 {
     .global & {
         padding: 5px 5px 5px 10px;
         border-left-color: currentcolor;
@@ -786,7 +786,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test8 {
+    [dir="ltr"] .test8 {
         left: auto;
         right: 10px;
         text-align: right;
@@ -797,7 +797,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"ltr\\"] .test9 {
+        [dir="ltr"] .test9 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -809,7 +809,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
             padding: 0 0.6em 0 1.7em;
         }
 
-        [dir=\\"ltr\\"] .test10 {
+        [dir="ltr"] .test10 {
             padding: 0 1.7em 0 0.6em;
         }
     }
@@ -827,7 +827,7 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
     }
 }
 
-[dir=\\"ltr\\"] .test11 {
+[dir="ltr"] .test11 {
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/overriding.test.ts.snap
+++ b/tests/__snapshots__/overriding.test.ts.snap
@@ -30,12 +30,12 @@ exports[`[[Mode: combined]] Overriding Tests:  Basic 1`] = `
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     left: 10px;
     right: 0;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     right: 10px;
     left: 0;
 }"
@@ -80,7 +80,7 @@ exports[`[[Mode: override]] Overriding Tests:  Basic 1`] = `
     right: 0;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     right: 10px;
     left: 0;
 }"

--- a/tests/__snapshots__/prefixed.test.ts.snap
+++ b/tests/__snapshots__/prefixed.test.ts.snap
@@ -29,19 +29,19 @@ exports[`[[Mode: combined]] Prefixed Tests:  Custom prefixes 1`] = `
     margin: 2px 16px 8px 4px;
 }
 
-.ltr [dir=\\"ltr\\"] .test3 {
+.ltr [dir="ltr"] .test3 {
     text-align: left;
 }
 
-.rtl [dir=\\"ltr\\"] .test3 {
+.rtl [dir="ltr"] .test3 {
     text-align: right;
 }
 
-.ltr [dir=\\"rtl\\"] .test3 {
+.ltr [dir="rtl"] .test3 {
     text-align: right;
 }
 
-.rtl [dir=\\"rtl\\"] .test3 {
+.rtl [dir="rtl"] .test3 {
     text-align: left;
 }
 
@@ -51,7 +51,7 @@ exports[`[[Mode: combined]] Prefixed Tests:  Custom prefixes 1`] = `
     width: 100%;    
 }
 
-.rtl [dir=\\"rtl\\"] .test5 {
+.rtl [dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
@@ -60,27 +60,27 @@ exports[`[[Mode: combined]] Prefixed Tests:  Custom prefixes 1`] = `
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
-.ltr [dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+.ltr [dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-.rtl [dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+.rtl [dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-.ltr [dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+.ltr [dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-.rtl [dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+.rtl [dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }"
 `;
 
@@ -89,82 +89,82 @@ exports[`[[Mode: combined]] Prefixed Tests:  Prefixed default 1`] = `
     color: red;
 }
 
-[dir=\\"ltr\\"] .rtl .test {
+[dir="ltr"] .rtl .test {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .rtl .test {
+[dir="rtl"] .rtl .test {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .ltr .test {
+[dir="ltr"] .ltr .test {
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .ltr .test {
+[dir="rtl"] .ltr .test {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .rtlignore .test2 {
+[dir="ltr"] .rtlignore .test2 {
     padding: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .rtlignore .test2 {
+[dir="rtl"] .rtlignore .test2 {
     padding: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .ltrignore .test2 {
+[dir="ltr"] .ltrignore .test2 {
     margin: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .ltrignore .test2 {
+[dir="rtl"] .ltrignore .test2 {
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .ltr .test4 {
+[dir="rtl"] .ltr .test4 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
-[dir=\\"rtl\\"] .test6 {
+[dir="rtl"] .test6 {
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .ltr .test7-ltr {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .ltr .test7-ltr {
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"ltr\\"] .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .rtl .test7-rtl {
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"rtl\\"] .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="rtl"] .rtl .test7-rtl {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-rtl.png");
 }"
 `;
 
@@ -181,27 +181,27 @@ exports[`[[Mode: combined]] Prefixed Tests:  Prefixed with array 1`] = `
     right: 10px;
 }
 
-.ltr .rtlignore .test2, [dir=\\"ltr\\"] .rtlignore .test2 {
+.ltr .rtlignore .test2, [dir="ltr"] .rtlignore .test2 {
     padding: 2px 4px 8px 16px;
 }
 
-.rtl .rtlignore .test2, [dir=\\"rtl\\"] .rtlignore .test2 {
+.rtl .rtlignore .test2, [dir="rtl"] .rtlignore .test2 {
     padding: 2px 16px 8px 4px;
 }
 
-.ltr .ltrignore .test2, [dir=\\"ltr\\"] .ltrignore .test2 {
+.ltr .ltrignore .test2, [dir="ltr"] .ltrignore .test2 {
     margin: 2px 4px 8px 16px;
 }
 
-.rtl .ltrignore .test2, [dir=\\"rtl\\"] .ltrignore .test2 {
+.rtl .ltrignore .test2, [dir="rtl"] .ltrignore .test2 {
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: right;
 }
 
@@ -211,28 +211,28 @@ exports[`[[Mode: combined]] Prefixed Tests:  Prefixed with array 1`] = `
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
-.rtl .test6, [dir=\\"rtl\\"] .test6 {
+.rtl .test6, [dir="rtl"] .test6 {
     left: 5px;
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-rtl.png");
 }"
 `;
 
@@ -241,98 +241,98 @@ exports[`[[Mode: combined]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
     color: red;
 }
 
-[dir=\\"ltr\\"] .rtl .test {
+[dir="ltr"] .rtl .test {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .rtl .test {
+[dir="rtl"] .rtl .test {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .ltr .test {
+[dir="ltr"] .ltr .test {
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .ltr .test {
+[dir="rtl"] .ltr .test {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .rtlignore .test2 {
+[dir="ltr"] .rtlignore .test2 {
     padding: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .rtlignore .test2 {
+[dir="rtl"] .rtlignore .test2 {
     padding: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .ltrignore .test2 {
+[dir="ltr"] .ltrignore .test2 {
     margin: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .ltrignore .test2 {
+[dir="rtl"] .ltrignore .test2 {
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] [dir=\\"ltr\\"] .test3 {
+[dir="ltr"] [dir="ltr"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test3 {
+[dir="rtl"] [dir="ltr"] .test3 {
     text-align: right;
 }
 
-[dir=\\"ltr\\"] [dir=\\"rtl\\"] .test3 {
+[dir="ltr"] [dir="rtl"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test3 {
+[dir="rtl"] [dir="rtl"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .ltr .test4 {
+[dir="rtl"] .ltr .test4 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test5 {
+[dir="rtl"] [dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
-[dir=\\"rtl\\"] .test6 {
+[dir="rtl"] .test6 {
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .ltr .test7-ltr {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .ltr .test7-ltr {
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"ltr\\"] .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .rtl .test7-rtl {
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"rtl\\"] .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="rtl"] .rtl .test7-rtl {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"ltr\\"] [dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="ltr"] [dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="rtl"] [dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-[dir=\\"ltr\\"] [dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="ltr"] [dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="rtl"] [dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }"
 `;
 
@@ -345,11 +345,11 @@ exports[`[[Mode: diff]] Prefixed Tests:  Custom prefixes 1`] = `
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: left;
 }
 
@@ -359,7 +359,7 @@ exports[`[[Mode: diff]] Prefixed Tests:  Custom prefixes 1`] = `
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
@@ -367,12 +367,12 @@ exports[`[[Mode: diff]] Prefixed Tests:  Custom prefixes 1`] = `
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }"
 `;
 
@@ -401,7 +401,7 @@ exports[`[[Mode: diff]] Prefixed Tests:  Prefixed default 1`] = `
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
@@ -410,11 +410,11 @@ exports[`[[Mode: diff]] Prefixed Tests:  Prefixed default 1`] = `
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }"
 `;
 
@@ -433,7 +433,7 @@ exports[`[[Mode: diff]] Prefixed Tests:  Prefixed with array 1`] = `
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
@@ -461,11 +461,11 @@ exports[`[[Mode: diff]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: left;
 }
 
@@ -475,7 +475,7 @@ exports[`[[Mode: diff]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
@@ -484,19 +484,19 @@ exports[`[[Mode: diff]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }"
 `;
 
@@ -529,19 +529,19 @@ exports[`[[Mode: override]] Prefixed Tests:  Custom prefixes 1`] = `
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: left;
 }
 
-.rtl [dir=\\"ltr\\"] .test3 {
+.rtl [dir="ltr"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: right;
 }
 
-.rtl [dir=\\"rtl\\"] .test3 {
+.rtl [dir="rtl"] .test3 {
     text-align: left;
 }
 
@@ -551,7 +551,7 @@ exports[`[[Mode: override]] Prefixed Tests:  Custom prefixes 1`] = `
     width: 100%;    
 }
 
-.rtl [dir=\\"rtl\\"] .test5 {
+.rtl [dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
@@ -560,27 +560,27 @@ exports[`[[Mode: override]] Prefixed Tests:  Custom prefixes 1`] = `
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-.rtl [dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+.rtl [dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-.rtl [dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+.rtl [dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }"
 `;
 
@@ -593,7 +593,7 @@ exports[`[[Mode: override]] Prefixed Tests:  Prefixed default 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .rtl .test {
+[dir="rtl"] .rtl .test {
     left: auto;
     right: 10px;
 }
@@ -602,7 +602,7 @@ exports[`[[Mode: override]] Prefixed Tests:  Prefixed default 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .ltr .test {
+[dir="rtl"] .ltr .test {
     right: auto;
     left: 10px;
 }
@@ -611,7 +611,7 @@ exports[`[[Mode: override]] Prefixed Tests:  Prefixed default 1`] = `
     padding: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .rtlignore .test2 {
+[dir="rtl"] .rtlignore .test2 {
     padding: 2px 16px 8px 4px;
 }
 
@@ -619,54 +619,54 @@ exports[`[[Mode: override]] Prefixed Tests:  Prefixed default 1`] = `
     margin: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .ltrignore .test2 {
+[dir="rtl"] .ltrignore .test2 {
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .ltr .test4 {
+[dir="rtl"] .ltr .test4 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
-[dir=\\"rtl\\"] .test6 {
+[dir="rtl"] .test6 {
     left: 5px;
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .ltr .test7-ltr {
+    background-image: url("/icons/icon-right.png");
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"rtl\\"] .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="rtl"] .rtl .test7-rtl {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-rtl.png");
 }"
 `;
 
@@ -687,7 +687,7 @@ exports[`[[Mode: override]] Prefixed Tests:  Prefixed with array 1`] = `
     padding: 2px 4px 8px 16px;
 }
 
-.rtl .rtlignore .test2, [dir=\\"rtl\\"] .rtlignore .test2 {
+.rtl .rtlignore .test2, [dir="rtl"] .rtlignore .test2 {
     padding: 2px 16px 8px 4px;
 }
 
@@ -695,15 +695,15 @@ exports[`[[Mode: override]] Prefixed Tests:  Prefixed with array 1`] = `
     margin: 2px 4px 8px 16px;
 }
 
-.rtl .ltrignore .test2, [dir=\\"rtl\\"] .ltrignore .test2 {
+.rtl .ltrignore .test2, [dir="rtl"] .ltrignore .test2 {
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: right;
 }
 
@@ -713,28 +713,28 @@ exports[`[[Mode: override]] Prefixed Tests:  Prefixed with array 1`] = `
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .test5 {
+[dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
-.rtl .test6, [dir=\\"rtl\\"] .test6 {
+.rtl .test6, [dir="rtl"] .test6 {
     left: 5px;
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-rtl.png");
 }"
 `;
 
@@ -747,7 +747,7 @@ exports[`[[Mode: override]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .rtl .test {
+[dir="rtl"] .rtl .test {
     left: auto;
     right: 10px;
 }
@@ -756,7 +756,7 @@ exports[`[[Mode: override]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .ltr .test {
+[dir="rtl"] .ltr .test {
     right: auto;
     left: 10px;
 }
@@ -765,7 +765,7 @@ exports[`[[Mode: override]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
     padding: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .rtlignore .test2 {
+[dir="rtl"] .rtlignore .test2 {
     padding: 2px 16px 8px 4px;
 }
 
@@ -773,69 +773,69 @@ exports[`[[Mode: override]] Prefixed Tests:  ignorePrefixedRules false 1`] = `
     margin: 2px 4px 8px 16px;
 }
 
-[dir=\\"rtl\\"] .ltrignore .test2 {
+[dir="rtl"] .ltrignore .test2 {
     margin: 2px 16px 8px 4px;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test3 {
+[dir="rtl"] [dir="ltr"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     text-align: right;
 }
 
-[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test3 {
+[dir="rtl"] [dir="rtl"] .test3 {
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .ltr .test4 {
+[dir="rtl"] .ltr .test4 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test5 {
+[dir="rtl"] [dir="rtl"] .test5 {
     transform: translate(10px, 20px);
 }
 
-[dir=\\"rtl\\"] .test6 {
+[dir="rtl"] .test6 {
     left: 5px;
 }
 
 .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .ltr .test7-ltr {
+    background-image: url("/icons/icon-right.png");
 }
 
 .ltr .test7-ltr {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
-[dir=\\"rtl\\"] .rtl .test7-rtl {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="rtl"] .rtl .test7-rtl {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }
 
-[dir=\\"rtl\\"] [dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="rtl"] [dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-[dir=\\"ltr\\"] .test8-ltr {
-    background-image: url(\\"/icons/icon-rtl.png\\");
+[dir="ltr"] .test8-ltr {
+    background-image: url("/icons/icon-rtl.png");
 }
 
-[dir=\\"rtl\\"] [dir=\\"rtl\\"] .test8-rtl {
-    background-image: url(\\"/icons/icon-ltr.png\\");
+[dir="rtl"] [dir="rtl"] .test8-rtl {
+    background-image: url("/icons/icon-ltr.png");
 }"
 `;

--- a/tests/__snapshots__/prefixes.test.ts.snap
+++ b/tests/__snapshots__/prefixes.test.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
 .ltr .test1, .ltr .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
@@ -17,6 +17,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .rtl .test1, .rtl .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -133,7 +134,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 
 .rtl .test11:hover,
 .rtl .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -315,19 +316,19 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -344,11 +345,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -356,11 +357,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
@@ -368,11 +369,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .ltr .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -382,11 +383,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .ltr .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+    background-image: url("/icons/icon-left.png");    
 }
 
 .rtl .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -616,14 +617,14 @@ html.rtl .test50 {
 
 exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix properties as arrays 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
 .ltr .test1, .left-to-right .test1, .ltr .test2, .left-to-right .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
@@ -631,6 +632,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .rtl .test1, .right-to-left .test1, .rtl .test2, .right-to-left .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -757,7 +759,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 .right-to-left .test11:hover,
 .rtl .test11:active,
 .right-to-left .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -939,19 +941,19 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -968,11 +970,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -980,11 +982,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
@@ -992,11 +994,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .ltr .test31, .left-to-right .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl .test31, .right-to-left .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1006,11 +1008,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .ltr .test32, .left-to-right .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+    background-image: url("/icons/icon-left.png");    
 }
 
 .rtl .test32, .right-to-left .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -1245,7 +1247,8 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .ltr .test1, .left-to-right .test1, .ltr .test2, .left-to-right .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
@@ -1253,7 +1256,8 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .rtl .test1, .right-to-left .test1, .rtl .test2, .right-to-left .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1262,7 +1266,6 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 
 .ltr .test1, .left-to-right .test1, .rtl .test1, .right-to-left .test1, .ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -1385,7 +1388,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 .right-to-left .test11:hover,
 .rtl .test11:active,
 .right-to-left .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -1567,19 +1570,19 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -1596,11 +1599,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -1608,11 +1611,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
@@ -1620,11 +1623,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .ltr .test31, .left-to-right .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl .test31, .right-to-left .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1634,11 +1637,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .ltr .test32, .left-to-right .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+    background-image: url("/icons/icon-left.png");    
 }
 
 .rtl .test32, .right-to-left .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -1868,14 +1871,14 @@ html.rtl .test50, html.right-to-left .test50 {
 
 exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with custom ltrPrefix and rtlPrefix 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
 .ltr.test1, .ltr.test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
@@ -1883,6 +1886,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .rtl.test1, .rtl.test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1999,7 +2003,7 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 
 .rtl.test11:hover,
 .rtl.test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2181,19 +2185,19 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2210,11 +2214,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2222,11 +2226,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
@@ -2234,11 +2238,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .ltr.test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
 }
 
 .rtl.test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2248,11 +2252,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .ltr.test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+    background-image: url("/icons/icon-left.png");    
 }
 
 .rtl.test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -2482,21 +2486,22 @@ html.rtl .test50 {
 
 exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with default prefixes 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
     color: #666;
     width: 100%;
 }
 
-[dir=\\"ltr\\"] > .test1, [dir=\\"ltr\\"] > .test2 {
+[dir="ltr"] > .test1, [dir="ltr"] > .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] > .test1, [dir=\\"rtl\\"] > .test2 {
+[dir="rtl"] > .test1, [dir="rtl"] > .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -2517,11 +2522,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     text-align: center;
 }
 
-[dir=\\"ltr\\"] > .test3 {
+[dir="ltr"] > .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] > .test3 {
+[dir="rtl"] > .test3 {
     direction: rtl;
 }
 
@@ -2532,12 +2537,12 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] > .test4 {
+[dir="ltr"] > .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] > .test4 {
+[dir="rtl"] > .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -2550,9 +2555,9 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     position: absolute;
 }
 
-[dir=\\"ltr\\"] > .test5,
-[dir=\\"ltr\\"] > .test6,
-[dir=\\"ltr\\"] > .test7 {
+[dir="ltr"] > .test5,
+[dir="ltr"] > .test6,
+[dir="ltr"] > .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -2560,9 +2565,9 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] > .test5,
-[dir=\\"rtl\\"] > .test6,
-[dir=\\"rtl\\"] > .test7 {
+[dir="rtl"] > .test5,
+[dir="rtl"] > .test6,
+[dir="rtl"] > .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -2576,11 +2581,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] > .test8 {
+[dir="ltr"] > .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] > .test8 {
+[dir="rtl"] > .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -2588,22 +2593,22 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] > .test9, [dir=\\"ltr\\"] > .test10 {
+[dir="ltr"] > .test9, [dir="ltr"] > .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] > .test9, [dir=\\"rtl\\"] > .test10 {
+[dir="rtl"] > .test9, [dir="rtl"] > .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] > .test11:hover,
-[dir=\\"ltr\\"] > .test11:active {
+[dir="ltr"] > .test11:hover,
+[dir="ltr"] > .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -2611,9 +2616,9 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] > .test11:hover,
-[dir=\\"rtl\\"] > .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] > .test11:hover,
+[dir="rtl"] > .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2636,11 +2641,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] > .test16:hover {
+[dir="ltr"] > .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] > .test16:hover {
+[dir="rtl"] > .test16:hover {
     padding-left: 20px;
 }
 
@@ -2662,11 +2667,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] > .test18 {
+[dir="ltr"] > .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] > .test18 {
+[dir="rtl"] > .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -2678,11 +2683,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] > .test18::after {
+[dir="ltr"] > .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] > .test18::after {
+[dir="rtl"] > .test18::after {
     right: 10px;
 }
 
@@ -2701,11 +2706,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] > .test18 {
+    [dir="ltr"] > .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] > .test18 {
+    [dir="rtl"] > .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -2753,12 +2758,12 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] > .test22 {
+[dir="ltr"] > .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] > .test22 {
+[dir="rtl"] > .test22 {
     right: 5px;
     left: 10px;
 }
@@ -2774,11 +2779,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] > .test24 {
+[dir="ltr"] > .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] > .test24 {
+[dir="rtl"] > .test24 {
     border: 1px solid #000;
 }
 
@@ -2795,19 +2800,19 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2824,11 +2829,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2836,23 +2841,23 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] > .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] > .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] > .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] > .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2861,35 +2866,35 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] > .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] > .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] > .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] > .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] > .test33 {
+[dir="ltr"] > .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] > .test33 {
+[dir="rtl"] > .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] > .example34 {
+[dir="rtl"] > .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] > .example35 {
+[dir="rtl"] > .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -2898,13 +2903,13 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 100%;
 }
 
-[dir=\\"ltr\\"] > .test36 {
+[dir="ltr"] > .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] > .test36 {
+[dir="rtl"] > .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2915,13 +2920,13 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 100%;
 }
 
-[dir=\\"ltr\\"] > .test37 {
+[dir="ltr"] > .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] > .test37 {
+[dir="rtl"] > .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -2932,13 +2937,13 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 100%;
 }
 
-[dir=\\"ltr\\"] > .test38 {
+[dir="ltr"] > .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] > .test38 {
+[dir="rtl"] > .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2948,11 +2953,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 50%;
 }
 
-[dir=\\"ltr\\"] > .test39 {
+[dir="ltr"] > .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] > .test39 {
+[dir="rtl"] > .test39 {
     margin-left: 10px;
 }
 
@@ -2961,11 +2966,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] > .test40 {
+[dir="ltr"] > .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] > .test40 {
+[dir="rtl"] > .test40 {
     left: 5px;
 }
 
@@ -2973,23 +2978,23 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] > .test41 {
+[dir="ltr"] > .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] > .test41 {
+[dir="rtl"] > .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] > .test42 {
+[dir="ltr"] > .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] > .test43 {
+[dir="ltr"] > .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -3030,11 +3035,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] > .test46 {
+    [dir="ltr"] > .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] > .test46 {
+    [dir="rtl"] > .test46 {
         text-align: right;
     }
 
@@ -3048,11 +3053,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] > .test48 {
+    [dir="ltr"] > .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] > .test48 {
+    [dir="rtl"] > .test48 {
         text-align: left;
     }
 
@@ -3061,11 +3066,11 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -3073,19 +3078,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] > .test51 {
+[dir="ltr"] > .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] > .test51 {
+[dir="rtl"] > .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -3096,6 +3101,7 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3137,7 +3143,7 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3175,19 +3181,19 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -3285,6 +3291,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix properties as arrays 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3326,7 +3333,7 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix properti
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3364,19 +3371,19 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix properti
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -3474,9 +3481,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bothPrefix properties as arrays and processUrls: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3518,7 +3525,7 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bothPr
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3556,19 +3563,19 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bothPr
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -3666,6 +3673,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with custom ltrPrefix and rtlPrefix 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3707,7 +3715,7 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with custom l
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3745,19 +3753,19 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with custom l
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -3855,6 +3863,7 @@ html .test50 {
 
 exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with default prefixes 1`] = `
 ".test1, .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3896,7 +3905,7 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with default 
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3934,19 +3943,19 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with default 
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4044,7 +4053,7 @@ html .test50 {
 
 exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -4056,6 +4065,7 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .rtl .test1, .rtl .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4158,7 +4168,7 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 
 .rtl .test11:hover,
 .rtl .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4330,19 +4340,19 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -4359,11 +4369,11 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -4371,31 +4381,31 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
 .rtl .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
 .rtl .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4610,7 +4620,7 @@ html.rtl .test50 {
 
 exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix properties as arrays 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -4622,6 +4632,7 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .rtl .test1, .right-to-left .test1, .rtl .test2, .right-to-left .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4729,7 +4740,7 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 .right-to-left .test11:hover,
 .rtl .test11:active,
 .right-to-left .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4901,19 +4912,19 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -4930,11 +4941,11 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -4942,31 +4953,31 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
 .rtl .test31, .right-to-left .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
 .rtl .test32, .right-to-left .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5181,7 +5192,8 @@ html.rtl .test50, html.right-to-left .test50 {
 
 exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bothPrefix properties as arrays and processUrls: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     color: #666;
     padding-right: 20px;
@@ -5191,7 +5203,8 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .rtl .test1, .right-to-left .test1, .rtl .test2, .right-to-left .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5201,7 +5214,6 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 
 .ltr .test1, .left-to-right .test1, .rtl .test1, .right-to-left .test1, .ltr .test2, .left-to-right .test2, .rtl .test2, .right-to-left .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -5304,7 +5316,7 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 .right-to-left .test11:hover,
 .rtl .test11:active,
 .right-to-left .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5476,19 +5488,19 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -5505,11 +5517,11 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -5517,31 +5529,31 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
 .rtl .test31, .right-to-left .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
 .rtl .test32, .right-to-left .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5756,7 +5768,7 @@ html.rtl .test50, html.right-to-left .test50 {
 
 exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with custom ltrPrefix and rtlPrefix 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -5768,6 +5780,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .rtl.test1, .rtl.test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5870,7 +5883,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with cust
 
 .rtl.test11:hover,
 .rtl.test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -6042,19 +6055,19 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -6071,11 +6084,11 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -6083,31 +6096,31 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with cust
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
 .rtl.test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
 .rtl.test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -6322,7 +6335,7 @@ html.rtl .test50 {
 
 exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with default prefixes 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -6333,7 +6346,8 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 100%;
 }
 
-[dir=\\"rtl\\"] > .test1, [dir=\\"rtl\\"] > .test2 {
+[dir="rtl"] > .test1, [dir="rtl"] > .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -6356,7 +6370,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     text-align: center;
 }
 
-[dir=\\"rtl\\"] > .test3 {
+[dir="rtl"] > .test3 {
     direction: rtl;
 }
 
@@ -6369,7 +6383,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] > .test4 {
+[dir="rtl"] > .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -6387,9 +6401,9 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] > .test5,
-[dir=\\"rtl\\"] > .test6,
-[dir=\\"rtl\\"] > .test7 {
+[dir="rtl"] > .test5,
+[dir="rtl"] > .test6,
+[dir="rtl"] > .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -6405,7 +6419,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] > .test8 {
+[dir="rtl"] > .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -6417,7 +6431,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] > .test9, [dir=\\"rtl\\"] > .test10 {
+[dir="rtl"] > .test9, [dir="rtl"] > .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -6434,9 +6448,9 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] > .test11:hover,
-[dir=\\"rtl\\"] > .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] > .test11:hover,
+[dir="rtl"] > .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -6463,7 +6477,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] > .test16:hover {
+[dir="rtl"] > .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -6487,7 +6501,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] > .test18 {
+[dir="rtl"] > .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -6500,7 +6514,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] > .test18::after {
+[dir="rtl"] > .test18::after {
     left: auto;
     right: 10px;
 }
@@ -6521,7 +6535,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] > .test18 {
+    [dir="rtl"] > .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -6574,7 +6588,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     right: 10px;
 }
 
-[dir=\\"rtl\\"] > .test22 {
+[dir="rtl"] > .test22 {
     right: 5px;
     left: 10px;
 }
@@ -6591,7 +6605,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] > .test24 {
+[dir="rtl"] > .test24 {
     border: 1px solid #000;
 }
 
@@ -6608,19 +6622,19 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -6637,11 +6651,11 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -6649,31 +6663,31 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] > .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] > .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] > .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] > .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -6681,20 +6695,20 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     left: 10px;
 }
 
-[dir=\\"rtl\\"] > .test33 {
+[dir="rtl"] > .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] > .example34 {
+[dir="rtl"] > .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] > .example35 {
+[dir="rtl"] > .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -6706,7 +6720,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 100%;
 }
 
-[dir=\\"ltr\\"] > .test36 {
+[dir="ltr"] > .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6721,13 +6735,13 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 100%;
 }
 
-[dir=\\"rtl\\"] > .test37 {
+[dir="rtl"] > .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] > .test37 {
+[dir="ltr"] > .test37 {
     text-align: right;
 }
 
@@ -6739,12 +6753,12 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 100%;
 }
 
-[dir=\\"rtl\\"] > .test38 {
+[dir="rtl"] > .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] > .test38 {
+[dir="ltr"] > .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -6754,7 +6768,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     width: 50%;
 }
 
-[dir=\\"ltr\\"] > .test39 {
+[dir="ltr"] > .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -6765,7 +6779,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     left: 5px;
 }
 
-[dir=\\"ltr\\"] > .test40 {
+[dir="ltr"] > .test40 {
     left: auto;
     right: 5px;
 }
@@ -6775,20 +6789,20 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     left: 10px;
 }
 
-[dir=\\"ltr\\"] > .test41 {
+[dir="ltr"] > .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] > .test42 {
+[dir="ltr"] > .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] > .test43 {
+[dir="ltr"] > .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -6830,7 +6844,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] > .test46 {
+    [dir="rtl"] > .test46 {
         text-align: right;
     }
 
@@ -6845,7 +6859,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] > .test48 {
+    [dir="ltr"] > .test48 {
         text-align: right;
     }
 
@@ -6858,7 +6872,7 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -6867,7 +6881,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -6876,7 +6890,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] > .test51 {
+[dir="rtl"] > .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/safe-prefix.test.ts.snap
@@ -7,19 +7,20 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test1, [dir] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -43,11 +44,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -61,12 +62,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -84,9 +85,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid 2px;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -94,9 +95,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -110,11 +111,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -122,22 +123,22 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -145,9 +146,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -170,11 +171,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -199,11 +200,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
                3s my-animation 6s ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -215,11 +216,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -238,11 +239,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -293,12 +294,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -314,11 +315,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -335,19 +336,19 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -364,11 +365,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -376,23 +377,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -404,35 +405,35 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -441,13 +442,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -458,13 +459,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -475,13 +476,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -491,11 +492,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -507,11 +508,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -519,23 +520,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -576,11 +577,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -594,11 +595,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -607,11 +608,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -619,19 +620,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -647,19 +648,20 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test1, [dir] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -683,11 +685,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -701,12 +703,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -724,9 +726,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid 2px;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -734,9 +736,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -750,11 +752,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -762,22 +764,22 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -785,9 +787,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -810,11 +812,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -834,13 +836,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     animation: 5s flip-ltr 1s ease-in-out,
                3s my-animation-ltr 6s ease-in-out;
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     animation: 5s flip-rtl 1s ease-in-out,
                3s my-animation-rtl 6s ease-in-out;
     padding: 10px 10px 40px 20px;
@@ -854,11 +856,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -887,11 +889,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -902,11 +904,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     animation-timing-function: ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test19 {
+[dir="ltr"] .test19 {
     animation-name: my-animation-ltr;
 }
 
-[dir=\\"rtl\\"] .test19 {
+[dir="rtl"] .test19 {
     animation-name: my-animation-rtl;
 }
 
@@ -916,11 +918,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     animation-timing-function: ease;
 }
 
-[dir=\\"ltr\\"] .test20 {
+[dir="ltr"] .test20 {
     animation-name: my-animation-ltr, no-flip;
 }
 
-[dir=\\"rtl\\"] .test20 {
+[dir="rtl"] .test20 {
     animation-name: my-animation-rtl, no-flip;
 }
 
@@ -966,12 +968,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -987,11 +989,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -1008,19 +1010,19 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -1037,11 +1039,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -1049,23 +1051,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1077,35 +1079,35 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1114,13 +1116,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1131,13 +1133,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -1148,13 +1150,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1164,11 +1166,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -1180,11 +1182,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -1192,23 +1194,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1236,11 +1238,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     }
 }
 
-[dir=\\"ltr\\"] .test44 {
+[dir="ltr"] .test44 {
     animation: 5s normalFlip-ltr 1s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test44 {
+[dir="rtl"] .test44 {
     animation: 5s normalFlip-rtl 1s ease-in-out;
 }
 
@@ -1268,11 +1270,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     }
 }
 
-[dir=\\"ltr\\"] .test45 {
+[dir="ltr"] .test45 {
     animation: 5s inversedFlip-ltr 1s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test45 {
+[dir="rtl"] .test45 {
     animation: 5s inversedFlip-rtl 1s ease-in-out;
 }
 
@@ -1281,11 +1283,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -1299,11 +1301,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -1312,11 +1314,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -1324,19 +1326,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1351,16 +1353,18 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1369,7 +1373,6 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -1389,11 +1392,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -1407,12 +1410,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -1430,9 +1433,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid 2px;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -1440,9 +1443,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -1456,11 +1459,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -1468,22 +1471,22 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -1491,9 +1494,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -1516,11 +1519,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -1545,11 +1548,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
                3s my-animation 6s ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -1561,11 +1564,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -1584,11 +1587,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -1639,12 +1642,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -1660,11 +1663,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -1681,19 +1684,19 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -1710,11 +1713,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -1722,23 +1725,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1750,35 +1753,35 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1787,13 +1790,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1804,13 +1807,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -1821,13 +1824,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1837,11 +1840,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -1853,11 +1856,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -1865,23 +1868,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1922,11 +1925,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -1940,11 +1943,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -1953,11 +1956,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -1965,19 +1968,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1993,19 +1996,20 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test1, [dir] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -2029,11 +2033,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: rtl;
 }
 
@@ -2047,12 +2051,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -2070,9 +2074,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid 2px;
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -2080,9 +2084,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -2096,11 +2100,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -2108,22 +2112,22 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -2131,9 +2135,9 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2156,11 +2160,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -2185,11 +2189,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
                3s my-animation 6s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -2201,11 +2205,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     right: 10px;
 }
 
@@ -2224,11 +2228,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -2279,12 +2283,12 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -2300,11 +2304,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #000;
 }
 
@@ -2321,19 +2325,19 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2350,11 +2354,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2362,23 +2366,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2390,35 +2394,35 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .example34 {
+[dir="ltr"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .example35 {
+[dir="ltr"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -2427,13 +2431,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -2444,13 +2448,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -2461,13 +2465,13 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
@@ -2477,11 +2481,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     width: 50%;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
@@ -2493,11 +2497,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
@@ -2505,23 +2509,23 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     color: #EFEFEF;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -2562,11 +2566,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
@@ -2580,11 +2584,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         cursor: wait;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -2593,11 +2597,11 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     }
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -2605,19 +2609,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -2628,9 +2632,9 @@ html[dir=\\"ltr\\"] .test50 {
 
 exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -2683,7 +2687,7 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} 1`]
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2756,32 +2760,32 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} 1`]
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     border: 1px solid gray;
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
@@ -2892,9 +2896,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and {processKeyFrames: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -2947,7 +2951,7 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3040,32 +3044,32 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     border: 1px solid gray;
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
@@ -3200,9 +3204,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and {processUrls: true} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3255,7 +3259,7 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3328,32 +3332,32 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     border: 1px solid gray;
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
@@ -3464,9 +3468,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and {source: rtl} 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3519,7 +3523,7 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3592,32 +3596,32 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     border: 1px solid gray;
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
@@ -3733,7 +3737,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test1, [dir] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -3742,7 +3746,8 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3768,7 +3773,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -3784,7 +3789,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -3807,9 +3812,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -3828,7 +3833,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -3843,7 +3848,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -3864,9 +3869,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3893,7 +3898,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -3920,7 +3925,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -3936,7 +3941,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -3960,7 +3965,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -4016,7 +4021,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -4033,7 +4038,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -4050,19 +4055,19 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -4079,11 +4084,11 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -4091,20 +4096,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -4112,13 +4117,13 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4129,20 +4134,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -4157,7 +4162,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -4175,13 +4180,13 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -4196,12 +4201,12 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -4214,7 +4219,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     margin-left: 10px;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -4228,7 +4233,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -4241,20 +4246,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -4296,7 +4301,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -4311,7 +4316,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -4324,7 +4329,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -4336,7 +4341,7 @@ html[dir] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -4345,7 +4350,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -4362,7 +4367,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test1, [dir] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -4371,7 +4376,8 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4397,7 +4403,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -4413,7 +4419,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -4436,9 +4442,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -4457,7 +4463,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -4472,7 +4478,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -4493,9 +4499,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4522,7 +4528,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -4549,7 +4555,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     animation: 5s flip-rtl 1s ease-in-out,
                3s my-animation-rtl 6s ease-in-out;
     padding: 10px 10px 40px 20px;
@@ -4567,7 +4573,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -4601,7 +4607,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -4613,7 +4619,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     animation-timing-function: ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test19 {
+[dir="rtl"] .test19 {
     animation-name: my-animation-rtl;
 }
 
@@ -4624,7 +4630,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     animation-timing-function: ease;
 }
 
-[dir=\\"rtl\\"] .test20 {
+[dir="rtl"] .test20 {
     animation-name: my-animation-rtl, no-flip;
 }
 
@@ -4675,7 +4681,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -4692,7 +4698,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -4709,19 +4715,19 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -4738,11 +4744,11 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -4750,20 +4756,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -4771,13 +4777,13 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4788,20 +4794,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -4816,7 +4822,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -4834,13 +4840,13 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -4855,12 +4861,12 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -4873,7 +4879,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     margin-left: 10px;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -4887,7 +4893,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -4900,20 +4906,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -4945,7 +4951,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     animation: 5s normalFlip-ltr 1s ease-in-out;
 }
 
-[dir=\\"rtl\\"] .test44 {
+[dir="rtl"] .test44 {
     animation: 5s normalFlip-rtl 1s ease-in-out;
 }
 
@@ -4977,7 +4983,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     animation: 5s inversedFlip-rtl 1s ease-in-out;
 }
 
-[dir=\\"ltr\\"] .test45 {
+[dir="ltr"] .test45 {
     animation: 5s inversedFlip-ltr 1s ease-in-out;
 }
 
@@ -4987,7 +4993,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -5002,7 +5008,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -5015,7 +5021,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -5027,7 +5033,7 @@ html[dir] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -5036,7 +5042,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -5053,15 +5059,17 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test1, [dir] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5071,7 +5079,6 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -5092,7 +5099,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -5108,7 +5115,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -5131,9 +5138,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -5152,7 +5159,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -5167,7 +5174,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -5188,9 +5195,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5217,7 +5224,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -5244,7 +5251,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -5260,7 +5267,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -5284,7 +5291,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -5340,7 +5347,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -5357,7 +5364,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -5374,19 +5381,19 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -5403,11 +5410,11 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -5415,20 +5422,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -5436,13 +5443,13 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5453,20 +5460,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -5481,7 +5488,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -5499,13 +5506,13 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -5520,12 +5527,12 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -5538,7 +5545,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     margin-left: 10px;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -5552,7 +5559,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -5565,20 +5572,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -5620,7 +5627,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -5635,7 +5642,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -5648,7 +5655,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -5660,7 +5667,7 @@ html[dir] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -5669,7 +5676,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -5686,7 +5693,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test1, [dir] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
     background-color: #FFF;
     background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
@@ -5695,7 +5702,8 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -5721,7 +5729,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: rtl;
 }
 
@@ -5737,7 +5745,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -5760,9 +5768,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -5781,7 +5789,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -5796,7 +5804,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -5817,9 +5825,9 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5846,7 +5854,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding-right: 20px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -5873,7 +5881,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -5889,7 +5897,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -5913,7 +5921,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -5969,7 +5977,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -5986,7 +5994,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #000;
 }
 
@@ -6003,19 +6011,19 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test25, [dir] .test26-ltr, [dir] .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 [dir] .test26-rtl {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 [dir] .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 [dir] .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -6032,11 +6040,11 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -6044,20 +6052,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 [dir] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -6065,13 +6073,13 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
 }
 
 [dir] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -6082,20 +6090,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .example34 {
+[dir="ltr"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .example35 {
+[dir="ltr"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -6110,7 +6118,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6128,7 +6136,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6146,7 +6154,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -6161,7 +6169,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     margin-left: 10px;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -6175,7 +6183,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -6188,20 +6196,20 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -6243,7 +6251,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -6258,7 +6266,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -6271,7 +6279,7 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -6283,7 +6291,7 @@ html[dir] .test50 {
     left: 10px;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -6292,7 +6300,7 @@ html[dir=\\"ltr\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map.test.ts.snap
+++ b/tests/__snapshots__/string-map.test.ts.snap
@@ -6,16 +6,18 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -24,7 +26,6 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -41,11 +42,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -56,12 +57,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -74,9 +75,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -84,9 +85,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -100,11 +101,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -112,22 +113,22 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -135,9 +136,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -160,11 +161,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -186,11 +187,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -202,11 +203,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -225,11 +226,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -277,12 +278,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -298,11 +299,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -319,19 +320,19 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -348,11 +349,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -360,23 +361,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -385,35 +386,35 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -422,13 +423,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -439,13 +440,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -456,13 +457,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -472,11 +473,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -485,11 +486,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -497,23 +498,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -554,11 +555,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -572,11 +573,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -585,11 +586,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -597,19 +598,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -624,16 +625,18 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -642,7 +645,6 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -659,11 +661,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -674,12 +676,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -692,9 +694,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -702,9 +704,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -718,11 +720,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -730,22 +732,22 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -753,9 +755,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -778,11 +780,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -804,11 +806,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -820,11 +822,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -843,11 +845,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -895,12 +897,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -916,11 +918,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -937,19 +939,19 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -966,11 +968,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -978,23 +980,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1003,35 +1005,35 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1040,13 +1042,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1057,13 +1059,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -1074,13 +1076,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1090,11 +1092,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -1103,11 +1105,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -1115,23 +1117,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1172,11 +1174,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -1190,11 +1192,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -1203,11 +1205,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -1215,19 +1217,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1242,16 +1244,18 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1260,7 +1264,6 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -1277,11 +1280,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -1292,12 +1295,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -1310,9 +1313,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -1320,9 +1323,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -1336,11 +1339,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -1348,22 +1351,22 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -1371,9 +1374,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -1396,11 +1399,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -1422,11 +1425,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -1438,11 +1441,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -1461,11 +1464,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -1513,12 +1516,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -1534,11 +1537,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -1555,19 +1558,19 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -1584,11 +1587,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -1596,23 +1599,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -1621,35 +1624,35 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -1658,13 +1661,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1675,13 +1678,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -1692,13 +1695,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -1708,11 +1711,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -1721,11 +1724,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -1733,23 +1736,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -1790,11 +1793,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -1808,11 +1811,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -1821,11 +1824,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -1833,19 +1836,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -1860,16 +1863,18 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test1, [dir=\\"ltr\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+[dir="ltr"] .test1, [dir="ltr"] .test2 {
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     padding-right: 20px;
     text-align: left;
     transform: translate(-50%, 50%);
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-left: 20px;
     text-align: right;
@@ -1878,7 +1883,6 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -1895,11 +1899,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     text-align: center;
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     direction: ltr;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -1910,12 +1914,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     border-radius: 2px 4px 8px 16px;
     text-shadow: red 99px -1px 1px, blue 99px 2px 1px;
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -1928,9 +1932,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     position: absolute;
 }
 
-[dir=\\"ltr\\"] .test5,
-[dir=\\"ltr\\"] .test6,
-[dir=\\"ltr\\"] .test7 {
+[dir="ltr"] .test5,
+[dir="ltr"] .test6,
+[dir="ltr"] .test7 {
     background: linear-gradient(0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #777 #888 #999;
     border-width: 1px 2px 3px 4px;
@@ -1938,9 +1942,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -1954,11 +1958,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     padding-left: 10%;
 }
 
-[dir=\\"ltr\\"] .test8 {
+[dir="ltr"] .test8 {
     background: linear-gradient(to left, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -1966,22 +1970,22 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"ltr\\"] .test9, [dir=\\"ltr\\"] .test10 {
+[dir="ltr"] .test9, [dir="ltr"] .test10 {
     background: linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     left: 5px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
     right: 5px;
 }
 
-[dir=\\"ltr\\"] .test11:hover,
-[dir=\\"ltr\\"] .test11:active {
+[dir="ltr"] .test11:hover,
+[dir="ltr"] .test11:active {
     font-family: Arial, Helvetica;
     font-size: 20px;
     color: '#FFF';
@@ -1989,9 +1993,9 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2014,11 +2018,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     padding-right: 10px;
 }
 
-[dir=\\"ltr\\"] .test16:hover {
+[dir="ltr"] .test16:hover {
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-left: 20px;
 }
 
@@ -2040,11 +2044,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     font-size: 10px;
 }
 
-[dir=\\"ltr\\"] .test18 {
+[dir="ltr"] .test18 {
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -2056,11 +2060,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     transform: translateX(5px);
 }
 
-[dir=\\"ltr\\"] .test18::after {
+[dir="ltr"] .test18::after {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     right: 10px;
 }
 
@@ -2079,11 +2083,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
         width: 100%;
     }
 
-    [dir=\\"ltr\\"] .test18 {
+    [dir="ltr"] .test18 {
         padding: 1px 2px 3px 4px;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -2131,12 +2135,12 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
 }
 
 /* Do not add reset values in override mode */
-[dir=\\"ltr\\"] .test22 {
+[dir="ltr"] .test22 {
     left: 5px;
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -2152,11 +2156,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test24 {
+[dir="ltr"] .test24 {
     border: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -2173,19 +2177,19 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -2202,11 +2206,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -2214,23 +2218,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
     border: 1px solid gray;
 }
 
-[dir=\\"ltr\\"] .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+[dir="ltr"] .test31 {
+    background-image: url("/icons/icon-left.png");
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
@@ -2239,35 +2243,35 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     border: 1px solid gray;    
 }
 
-[dir=\\"ltr\\"] .test32 {
-    background-image: url(\\"/icons/icon-left.png\\");    
+[dir="ltr"] .test32 {
+    background-image: url("/icons/icon-left.png");    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test33 {
+[dir="ltr"] .test33 {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -2276,13 +2280,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test36 {
+[dir="rtl"] .test36 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2293,13 +2297,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     border-left: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: left;
@@ -2310,13 +2314,13 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     border-left: 1px solid #666;
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-right: 1px solid #666;
     padding: 10px 5px 10px 20px;
     text-align: left;
@@ -2326,11 +2330,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-right: 10px;
 }
 
-[dir=\\"rtl\\"] .test39 {
+[dir="rtl"] .test39 {
     margin-left: 10px;
 }
 
@@ -2339,11 +2343,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     padding: 10px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     right: 5px;
 }
 
-[dir=\\"rtl\\"] .test40 {
+[dir="rtl"] .test40 {
     left: 5px;
 }
 
@@ -2351,23 +2355,23 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     color: #EFEFEF;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .test41 {
+[dir="rtl"] .test41 {
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -2408,11 +2412,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test46 {
+    [dir="ltr"] .test46 {
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -2426,11 +2430,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
         cursor: wait;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
-    [dir=\\"rtl\\"] .test48 {
+    [dir="rtl"] .test48 {
         text-align: left;
     }
 
@@ -2439,11 +2443,11 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     }
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     text-align: left;
 }
 
@@ -2451,19 +2455,19 @@ html .test50 {
     color: red;
 }
 
-html[dir=\\"ltr\\"] .test50 {
+html[dir="ltr"] .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     right: 10px;
 }
 
-[dir=\\"ltr\\"] .test51 {
+[dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-right: 1px solid #FFF;
 }
 
@@ -2474,9 +2478,9 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and processUrls: true (different lenghts) 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -2518,7 +2522,7 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2556,19 +2560,19 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -2666,9 +2670,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and processUrls: true (different types) 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -2710,7 +2714,7 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2748,19 +2752,19 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -2858,9 +2862,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] String Map Tests:  custom string map and processUrls: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -2902,7 +2906,7 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map and processUrls: tr
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -2940,23 +2944,23 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map and processUrls: tr
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -3054,9 +3058,9 @@ html .test50 {
 
 exports[`[[Mode: diff]] String Map Tests:  custom string map without names and processUrls: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
     background-color: #FFF;
-    background-position: 10px 20px;
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3098,7 +3102,7 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map without names and p
 
 .test11:hover,
 .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3136,23 +3140,23 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map without names and p
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -3250,7 +3254,8 @@ html .test50 {
 
 exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and processUrls: true (different lenghts) 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     color: #666;
     padding-right: 20px;
@@ -3259,8 +3264,9 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3270,7 +3276,6 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -3288,7 +3293,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -3301,7 +3306,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -3319,9 +3324,9 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -3337,7 +3342,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -3349,7 +3354,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -3366,9 +3371,9 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3395,7 +3400,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -3419,7 +3424,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -3432,7 +3437,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -3453,7 +3458,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -3506,7 +3511,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -3523,7 +3528,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -3540,19 +3545,19 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -3569,11 +3574,11 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -3581,31 +3586,31 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -3613,20 +3618,20 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -3638,7 +3643,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -3653,13 +3658,13 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -3671,12 +3676,12 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -3686,7 +3691,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -3697,7 +3702,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -3707,20 +3712,20 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -3762,7 +3767,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -3777,7 +3782,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -3790,7 +3795,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -3799,7 +3804,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -3808,7 +3813,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -3820,7 +3825,8 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and processUrls: true (different types) 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     color: #666;
     padding-right: 20px;
@@ -3829,8 +3835,9 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -3840,7 +3847,6 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -3858,7 +3864,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -3871,7 +3877,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -3889,9 +3895,9 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -3907,7 +3913,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -3919,7 +3925,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -3936,9 +3942,9 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -3965,7 +3971,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -3989,7 +3995,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -4002,7 +4008,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -4023,7 +4029,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -4076,7 +4082,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -4093,7 +4099,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -4110,19 +4116,19 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-next {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -4139,11 +4145,11 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -4151,31 +4157,31 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4183,20 +4189,20 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -4208,7 +4214,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -4223,13 +4229,13 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -4241,12 +4247,12 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -4256,7 +4262,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -4267,7 +4273,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -4277,20 +4283,20 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -4332,7 +4338,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -4347,7 +4353,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -4360,7 +4366,7 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -4369,7 +4375,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -4378,7 +4384,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -4390,7 +4396,8 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     color: #666;
     padding-right: 20px;
@@ -4399,8 +4406,9 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4410,7 +4418,6 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -4428,7 +4435,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -4441,7 +4448,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -4459,9 +4466,9 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -4477,7 +4484,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -4489,7 +4496,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -4506,9 +4513,9 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -4535,7 +4542,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -4559,7 +4566,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -4572,7 +4579,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -4593,7 +4600,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -4646,7 +4653,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -4663,7 +4670,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -4680,19 +4687,19 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -4709,11 +4716,11 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -4721,31 +4728,31 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -4753,20 +4760,20 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -4778,7 +4785,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -4793,13 +4800,13 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -4811,12 +4818,12 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -4826,7 +4833,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -4837,7 +4844,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -4847,20 +4854,20 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -4902,7 +4909,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -4917,7 +4924,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -4930,7 +4937,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -4939,7 +4946,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -4948,7 +4955,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }
@@ -4960,7 +4967,8 @@ html[dir=\\"rtl\\"] .test50 {
 
 exports[`[[Mode: override]] String Map Tests:  custom string map without names and processUrls: true 1`] = `
 ".test1, .test2 {
-    background: url(\\"/folder/subfolder/icons/ltr/chevron-left.png\\");
+    background: url("/folder/subfolder/icons/ltr/chevron-left.png");
+    background-position: 10px 20px;
     border-radius: 0 2px 0 8px;
     color: #666;
     padding-right: 20px;
@@ -4969,8 +4977,9 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test1, [dir=\\"rtl\\"] .test2 {
-    background: url(\\"/folder/subfolder/icons/rtl/chevron-right.png\\");
+[dir="rtl"] .test1, [dir="rtl"] .test2 {
+    background: url("/folder/subfolder/icons/rtl/chevron-right.png");
+    background-position: right 10px top 20px;
     border-radius: 2px 0 8px 0;
     padding-right: 0;
     padding-left: 20px;
@@ -4980,7 +4989,6 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
 
 [dir] .test1, [dir] .test2 {
     background-color: #FFF;
-    background-position: 10px 20px;
 }
 
 .test2 {
@@ -4998,7 +5006,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     text-align: center;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     direction: rtl;
 }
 
@@ -5011,7 +5019,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     transform: scale(0.5, 0.5);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     border-radius: 4px 2px 16px 8px;
     text-shadow: red -99px -1px 1px, blue -99px 2px 1px;
 }
@@ -5029,9 +5037,9 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test5,
-[dir=\\"rtl\\"] .test6,
-[dir=\\"rtl\\"] .test7 {
+[dir="rtl"] .test5,
+[dir="rtl"] .test6,
+[dir="rtl"] .test7 {
     background: linear-gradient(-0.25turn, #3F87A6, #EBF8E1, #F69D3C);
     border-color: #666 #999 #888 #777;
     border-width: 1px 4px 3px 2px;
@@ -5047,7 +5055,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     padding-left: 10%;
 }
 
-[dir=\\"rtl\\"] .test8 {
+[dir="rtl"] .test8 {
     background: linear-gradient(to right, #333, #333 50%, #EEE 75%, #333 75%);
 }
 
@@ -5059,7 +5067,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     padding: 0px 2px 3px 4px;
 }
 
-[dir=\\"rtl\\"] .test9, [dir=\\"rtl\\"] .test10 {
+[dir="rtl"] .test9, [dir="rtl"] .test10 {
     background: linear-gradient(-217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%),
                 linear-gradient(-127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%),
                 linear-gradient(-336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
@@ -5076,9 +5084,9 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test11:hover,
-[dir=\\"rtl\\"] .test11:active {
-    font-family: \\"Droid Arabic Kufi\\", Arial, Helvetica;
+[dir="rtl"] .test11:hover,
+[dir="rtl"] .test11:active {
+    font-family: "Droid Arabic Kufi", Arial, Helvetica;
     font-size: 30px;
     color: #000;
     transform: translateY(10px) scaleX(-1);
@@ -5105,7 +5113,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     padding-right: 20px;
 }
 
-[dir=\\"rtl\\"] .test16:hover {
+[dir="rtl"] .test16:hover {
     padding-right: 0;
     padding-left: 20px;
 }
@@ -5129,7 +5137,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     padding: 10px 20px 40px 10px;
 }
 
-[dir=\\"rtl\\"] .test18 {
+[dir="rtl"] .test18 {
     padding: 10px 10px 40px 20px;
 }
 
@@ -5142,7 +5150,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     transform: translateX(5px);
 }
 
-[dir=\\"rtl\\"] .test18::after {
+[dir="rtl"] .test18::after {
     left: auto;
     right: 10px;
 }
@@ -5163,7 +5171,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
         width: 100%;
     }
 
-    [dir=\\"rtl\\"] .test18 {
+    [dir="rtl"] .test18 {
         padding: 1px 4px 3px 2px;
     }
 }
@@ -5216,7 +5224,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     right: 10px;
 }
 
-[dir=\\"rtl\\"] .test22 {
+[dir="rtl"] .test22 {
     right: 5px;
     left: 10px;
 }
@@ -5233,7 +5241,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     padding: 10px;
 }
 
-[dir=\\"rtl\\"] .test24 {
+[dir="rtl"] .test24 {
     border: 1px solid #000;
 }
 
@@ -5250,19 +5258,19 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
 }
 
 .test25, .test26-ltr, .test27 {
-    background-image: url(\\"/icons/icon-l.png\\")
+    background-image: url("/icons/icon-l.png")
 }
 
 .test26-ltr {
-    background-image: url(\\"/icons/icon-r.png\\")
+    background-image: url("/icons/icon-r.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-p.png\\")
+    background-image: url("/icons/icon-p.png")
 }
 
 .test27-prev {
-    background-image: url(\\"/icons/icon-n.png\\")
+    background-image: url("/icons/icon-n.png")
 }
 
 .test28 {
@@ -5279,11 +5287,11 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .test28-left::before {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .testleft29 {
@@ -5291,31 +5299,31 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
 }
 
 .testleft30 {
-    content: \\"keyboard_arrow_left\\";
+    content: "keyboard_arrow_left";
 }
 
 .testright30 {
-    content: \\"keyboard_arrow_right\\";
+    content: "keyboard_arrow_right";
 }
 
 .test31 {
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     border: 1px solid gray;
 }
 
-[dir=\\"rtl\\"] .test31 {
-    background-image: url(\\"/icons/icon-right.png\\");
+[dir="rtl"] .test31 {
+    background-image: url("/icons/icon-right.png");
 }
 
 .test32 {
     align-items: center;
-    background-image: url(\\"/icons/icon-left.png\\");
+    background-image: url("/icons/icon-left.png");
     background-repeat: no-repeat;
     border: 1px solid gray;    
 }
 
-[dir=\\"rtl\\"] .test32 {
-    background-image: url(\\"/icons/icon-right.png\\");    
+[dir="rtl"] .test32 {
+    background-image: url("/icons/icon-right.png");    
 }
 
 .test33 {
@@ -5323,20 +5331,20 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test33 {
+[dir="rtl"] .test33 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"rtl\\"] .example34 {
+[dir="rtl"] .example34 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"rtl\\"] .example35 {
+[dir="rtl"] .example35 {
     transform: translate(10px, 20px);
 }
 
@@ -5348,7 +5356,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"ltr\\"] .test36 {
+[dir="ltr"] .test36 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
@@ -5363,13 +5371,13 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test37 {
+[dir="rtl"] .test37 {
     border-left: none;
     border-right: 1px solid #666;
     padding: 10px 20px 10px 5px;
 }
 
-[dir=\\"ltr\\"] .test37 {
+[dir="ltr"] .test37 {
     text-align: right;
 }
 
@@ -5381,12 +5389,12 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     width: 100%;
 }
 
-[dir=\\"rtl\\"] .test38 {
+[dir="rtl"] .test38 {
     border-left: none;
     border-right: 1px solid #666;
 }
 
-[dir=\\"ltr\\"] .test38 {
+[dir="ltr"] .test38 {
     padding: 10px 20px 10px 5px;
     text-align: right;
 }
@@ -5396,7 +5404,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     width: 50%;
 }
 
-[dir=\\"ltr\\"] .test39 {
+[dir="ltr"] .test39 {
     margin-left: 0;
     margin-right: 10px;
 }
@@ -5407,7 +5415,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     left: 5px;
 }
 
-[dir=\\"ltr\\"] .test40 {
+[dir="ltr"] .test40 {
     left: auto;
     right: 5px;
 }
@@ -5417,20 +5425,20 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     left: 10px;
 }
 
-[dir=\\"ltr\\"] .test41 {
+[dir="ltr"] .test41 {
     left: auto;
     right: 10px;
     height: 50px;
     width: 100px;
 }
 
-[dir=\\"ltr\\"] .test42 {
+[dir="ltr"] .test42 {
     color: #EFEFEF;
     left: 10px;
     width: 100%;    
 }
 
-[dir=\\"ltr\\"] .test43 {
+[dir="ltr"] .test43 {
     transform: translate(10px, 20px);
 }
 
@@ -5472,7 +5480,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
         text-align: left;
     }
 
-    [dir=\\"rtl\\"] .test46 {
+    [dir="rtl"] .test46 {
         text-align: right;
     }
 
@@ -5487,7 +5495,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
         text-align: left;
     }
 
-    [dir=\\"ltr\\"] .test48 {
+    [dir="ltr"] .test48 {
         text-align: right;
     }
 
@@ -5500,7 +5508,7 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     text-align: left;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     text-align: right;
 }
 
@@ -5509,7 +5517,7 @@ html .test50 {
     left: 10px;
 }
 
-html[dir=\\"rtl\\"] .test50 {
+html[dir="rtl"] .test50 {
     left: auto;
     right: 10px;
 }
@@ -5518,7 +5526,7 @@ html[dir=\\"rtl\\"] .test50 {
     border-left: 1px solid #FFF;
 }
 
-[dir=\\"rtl\\"] .test51 {
+[dir="rtl"] .test51 {
     border-left: none;
     border-right: 1px solid #FFF;
 }

--- a/tests/__snapshots__/variables.test.ts.snap
+++ b/tests/__snapshots__/variables.test.ts.snap
@@ -19,11 +19,11 @@ exports[`[[Mode: combined]] Variables Tests: aliases default 1`] = `
     padding: var(--large-padding);
 }
 
-[dir=\\"ltr\\"] .test1.large {
+[dir="ltr"] .test1.large {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     right: 10px;
 }
 
@@ -31,7 +31,7 @@ exports[`[[Mode: combined]] Variables Tests: aliases default 1`] = `
     margin: var(--custom-margin);
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 20px)
@@ -40,7 +40,7 @@ exports[`[[Mode: combined]] Variables Tests: aliases default 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -48,12 +48,12 @@ exports[`[[Mode: combined]] Variables Tests: aliases default 1`] = `
         env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     margin-right: env(safe-area-inset-right, 10px);
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"
@@ -64,14 +64,14 @@ exports[`[[Mode: combined]] Variables Tests: aliases map 1`] = `
     --custom-margin: 2px;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     --small-padding: 2px 4px 8px 16px;
     --large-padding: 4px 8px 16px 32px;
     --small-margin: 2px 4px 8px 16px;
     --large-margin: 4px 8px 16px 32px;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     --small-padding: 2px 16px 8px 4px;
     --large-padding: 4px 32px 16px 8px;
     --small-margin: 2px 16px 8px 4px;
@@ -88,11 +88,11 @@ exports[`[[Mode: combined]] Variables Tests: aliases map 1`] = `
     padding: var(--large-padding);
 }
 
-[dir=\\"ltr\\"] .test1.large {
+[dir="ltr"] .test1.large {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     right: 10px;
 }
 
@@ -100,7 +100,7 @@ exports[`[[Mode: combined]] Variables Tests: aliases map 1`] = `
     margin: var(--custom-margin);
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 20px)
@@ -109,7 +109,7 @@ exports[`[[Mode: combined]] Variables Tests: aliases map 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -117,12 +117,12 @@ exports[`[[Mode: combined]] Variables Tests: aliases map 1`] = `
         env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     margin-right: env(safe-area-inset-right, 10px);
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"
@@ -133,14 +133,14 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = false 1`] = `
     --custom-margin: 2px;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     --small-padding: 2px 4px 8px 16px;
     --large-padding: 4px 8px 16px 32px;
     --small-margin: 2px 4px 8px 16px;
     --large-margin: 4px 8px 16px 32px;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     --small-padding: 2px 16px 8px 4px;
     --large-padding: 4px 32px 16px 8px;
     --small-margin: 2px 16px 8px 4px;
@@ -157,11 +157,11 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = false 1`] = `
     padding: var(--large-padding);
 }
 
-[dir=\\"ltr\\"] .test1.large {
+[dir="ltr"] .test1.large {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     right: 10px;
 }
 
@@ -169,7 +169,7 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = false 1`] = `
     margin: var(--custom-margin);
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 20px)
@@ -178,7 +178,7 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = false 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-left, 40px)
@@ -186,12 +186,12 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = false 1`] = `
         env(safe-area-inset-right, 20px);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     margin-right: env(safe-area-inset-right, 10px);
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-right, 10px);
     margin-right: env(safe-area-inset-left, 20px);
 }"
@@ -202,14 +202,14 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = true 1`] = `
     --custom-margin: 2px;
 }
 
-[dir=\\"ltr\\"]:root {
+[dir="ltr"]:root {
     --small-padding: 2px 4px 8px 16px;
     --large-padding: 4px 8px 16px 32px;
     --small-margin: 2px 4px 8px 16px;
     --large-margin: 4px 8px 16px 32px;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     --small-padding: 2px 16px 8px 4px;
     --large-padding: 4px 32px 16px 8px;
     --small-margin: 2px 16px 8px 4px;
@@ -226,11 +226,11 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = true 1`] = `
     padding: var(--large-padding);
 }
 
-[dir=\\"ltr\\"] .test1.large {
+[dir="ltr"] .test1.large {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     right: 10px;
 }
 
@@ -238,7 +238,7 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = true 1`] = `
     margin: var(--custom-margin);
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 20px)
@@ -247,7 +247,7 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = true 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -255,12 +255,12 @@ exports[`[[Mode: combined]] Variables Tests: processEnv = true 1`] = `
         env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     margin-right: env(safe-area-inset-right, 10px);
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"
@@ -285,11 +285,11 @@ exports[`[[Mode: combined]] Variables Tests: wrong aliases 1`] = `
     padding: var(--large-padding);
 }
 
-[dir=\\"ltr\\"] .test1.large {
+[dir="ltr"] .test1.large {
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     right: 10px;
 }
 
@@ -297,7 +297,7 @@ exports[`[[Mode: combined]] Variables Tests: wrong aliases 1`] = `
     margin: var(--custom-margin);
 }
 
-[dir=\\"ltr\\"] .test3 {
+[dir="ltr"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 20px)
@@ -306,7 +306,7 @@ exports[`[[Mode: combined]] Variables Tests: wrong aliases 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -314,12 +314,12 @@ exports[`[[Mode: combined]] Variables Tests: wrong aliases 1`] = `
         env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"ltr\\"] .test4 {
+[dir="ltr"] .test4 {
     margin-right: env(safe-area-inset-right, 10px);
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"
@@ -466,7 +466,7 @@ exports[`[[Mode: override]] Variables Tests: aliases default 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     left: auto;
     right: 10px;
 }
@@ -484,7 +484,7 @@ exports[`[[Mode: override]] Variables Tests: aliases default 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -497,7 +497,7 @@ exports[`[[Mode: override]] Variables Tests: aliases default 1`] = `
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"
@@ -512,7 +512,7 @@ exports[`[[Mode: override]] Variables Tests: aliases map 1`] = `
     --large-margin: 4px 8px 16px 32px;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     --small-padding: 2px 16px 8px 4px;
     --large-padding: 4px 32px 16px 8px;
     --small-margin: 2px 16px 8px 4px;
@@ -530,7 +530,7 @@ exports[`[[Mode: override]] Variables Tests: aliases map 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     left: auto;
     right: 10px;
 }
@@ -548,7 +548,7 @@ exports[`[[Mode: override]] Variables Tests: aliases map 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -561,7 +561,7 @@ exports[`[[Mode: override]] Variables Tests: aliases map 1`] = `
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"
@@ -576,7 +576,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = false 1`] = `
     --large-margin: 4px 8px 16px 32px;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     --small-padding: 2px 16px 8px 4px;
     --large-padding: 4px 32px 16px 8px;
     --small-margin: 2px 16px 8px 4px;
@@ -594,7 +594,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = false 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     left: auto;
     right: 10px;
 }
@@ -612,7 +612,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = false 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-left, 40px)
@@ -625,7 +625,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = false 1`] = `
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-right, 10px);
     margin-right: env(safe-area-inset-left, 20px);
 }"
@@ -640,7 +640,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = true 1`] = `
     --large-margin: 4px 8px 16px 32px;
 }
 
-[dir=\\"rtl\\"]:root {
+[dir="rtl"]:root {
     --small-padding: 2px 16px 8px 4px;
     --large-padding: 4px 32px 16px 8px;
     --small-margin: 2px 16px 8px 4px;
@@ -658,7 +658,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = true 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     left: auto;
     right: 10px;
 }
@@ -676,7 +676,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = true 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -689,7 +689,7 @@ exports[`[[Mode: override]] Variables Tests: processEnv = true 1`] = `
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"
@@ -715,7 +715,7 @@ exports[`[[Mode: override]] Variables Tests: wrong aliases 1`] = `
     left: 10px;
 }
 
-[dir=\\"rtl\\"] .test1.large {
+[dir="rtl"] .test1.large {
     left: auto;
     right: 10px;
 }
@@ -733,7 +733,7 @@ exports[`[[Mode: override]] Variables Tests: wrong aliases 1`] = `
     ;
 }
 
-[dir=\\"rtl\\"] .test3 {
+[dir="rtl"] .test3 {
     padding:
         env(safe-area-inset-top, 10px)
         env(safe-area-inset-right, 40px)
@@ -746,7 +746,7 @@ exports[`[[Mode: override]] Variables Tests: wrong aliases 1`] = `
     margin-left: env(safe-area-inset-left, 20px);
 }
 
-[dir=\\"rtl\\"] .test4 {
+[dir="rtl"] .test4 {
     margin-left: env(safe-area-inset-left, 10px);
     margin-right: env(safe-area-inset-right, 20px);
 }"

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,6 +185,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
+"@babel/helper-plugin-utils@^7.18.6":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz#4796bb14961521f0f8715990bee2fb6e51ce21bf"
+  integrity sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==
+
 "@babel/helper-simple-access@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz#d656654b9ea08dbb9659b69d61063ccd343ff0f7"
@@ -287,6 +292,13 @@
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-jsx@^7.7.2":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
+  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
@@ -406,14 +418,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eslint/eslintrc@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
-  integrity sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==
+"@eslint/eslintrc@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.2.tgz#58b69582f3b7271d8fa67fe5251767a5b38ea356"
+  integrity sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.3.2"
+    espree "^9.4.0"
     globals "^13.15.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
@@ -421,14 +433,24 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@humanwhocodes/config-array@^0.9.2":
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
-  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+"@humanwhocodes/config-array@^0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
+  integrity sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
     minimatch "^3.0.4"
+
+"@humanwhocodes/gitignore-to-minimatch@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz#316b0a63b91c10e53f242efb4ace5c3b34e8728d"
+  integrity sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
@@ -451,110 +473,110 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/console@^28.1.1":
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-28.1.1.tgz#305f8ca50b6e70413839f54c0e002b60a0f2fd7d"
-  integrity sha512-0RiUocPVFEm3WRMOStIHbRWllG6iW6E3/gUPnf4lkrVFyXIIDeCe+vlKeYyFOMhB2EPE6FLFCNADSOOQMaqvyA==
+"@jest/console@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.0.3.tgz#a222ab87e399317a89db88a58eaec289519e807a"
+  integrity sha512-cGg0r+klVHSYnfE977S9wmpuQ9L+iYuYgL+5bPXiUlUynLLYunRxswEmhBzvrSKGof5AKiHuTTmUKAqRcDY9dg==
   dependencies:
-    "@jest/types" "^28.1.1"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^28.1.1"
-    jest-util "^28.1.1"
+    jest-message-util "^29.0.3"
+    jest-util "^29.0.3"
     slash "^3.0.0"
 
-"@jest/core@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-28.1.2.tgz#eac519b9acbd154313854b8823a47b5c645f785a"
-  integrity sha512-Xo4E+Sb/nZODMGOPt2G3cMmCBqL4/W2Ijwr7/mrXlq4jdJwcFQ/9KrrJZT2adQRk2otVBXXOz1GRQ4Z5iOgvRQ==
+"@jest/core@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.0.3.tgz#ba22a9cbd0c7ba36e04292e2093c547bf53ec1fd"
+  integrity sha512-1d0hLbOrM1qQE3eP3DtakeMbKTcXiXP3afWxqz103xPyddS2NhnNghS7MaXx1dcDt4/6p4nlhmeILo2ofgi8cQ==
   dependencies:
-    "@jest/console" "^28.1.1"
-    "@jest/reporters" "^28.1.2"
-    "@jest/test-result" "^28.1.1"
-    "@jest/transform" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/console" "^29.0.3"
+    "@jest/reporters" "^29.0.3"
+    "@jest/test-result" "^29.0.3"
+    "@jest/transform" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     exit "^0.1.2"
     graceful-fs "^4.2.9"
-    jest-changed-files "^28.0.2"
-    jest-config "^28.1.2"
-    jest-haste-map "^28.1.1"
-    jest-message-util "^28.1.1"
-    jest-regex-util "^28.0.2"
-    jest-resolve "^28.1.1"
-    jest-resolve-dependencies "^28.1.2"
-    jest-runner "^28.1.2"
-    jest-runtime "^28.1.2"
-    jest-snapshot "^28.1.2"
-    jest-util "^28.1.1"
-    jest-validate "^28.1.1"
-    jest-watcher "^28.1.1"
+    jest-changed-files "^29.0.0"
+    jest-config "^29.0.3"
+    jest-haste-map "^29.0.3"
+    jest-message-util "^29.0.3"
+    jest-regex-util "^29.0.0"
+    jest-resolve "^29.0.3"
+    jest-resolve-dependencies "^29.0.3"
+    jest-runner "^29.0.3"
+    jest-runtime "^29.0.3"
+    jest-snapshot "^29.0.3"
+    jest-util "^29.0.3"
+    jest-validate "^29.0.3"
+    jest-watcher "^29.0.3"
     micromatch "^4.0.4"
-    pretty-format "^28.1.1"
-    rimraf "^3.0.0"
+    pretty-format "^29.0.3"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-28.1.2.tgz#94a052c0c5f9f8c8e6d13ea6da78dbc5d7d9b85b"
-  integrity sha512-I0CR1RUMmOzd0tRpz10oUfaChBWs+/Hrvn5xYhMEF/ZqrDaaeHwS8yDBqEWCrEnkH2g+WE/6g90oBv3nKpcm8Q==
+"@jest/environment@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.0.3.tgz#7745ec30a954e828e8cc6df6a13280d3b51d8f35"
+  integrity sha512-iKl272NKxYNQNqXMQandAIwjhQaGw5uJfGXduu8dS9llHi8jV2ChWrtOAVPnMbaaoDhnI3wgUGNDvZgHeEJQCA==
   dependencies:
-    "@jest/fake-timers" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/fake-timers" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
-    jest-mock "^28.1.1"
+    jest-mock "^29.0.3"
 
-"@jest/expect-utils@^28.1.1":
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-28.1.1.tgz#d84c346025b9f6f3886d02c48a6177e2b0360587"
-  integrity sha512-n/ghlvdhCdMI/hTcnn4qV57kQuV9OTsZzH1TTCVARANKhl6hXJqLKUkwX69ftMGpsbpt96SsDD8n8LD2d9+FRw==
+"@jest/expect-utils@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.0.3.tgz#f5bb86f5565bf2dacfca31ccbd887684936045b2"
+  integrity sha512-i1xUkau7K/63MpdwiRqaxgZOjxYs4f0WMTGJnYwUKubsNRZSeQbLorS7+I4uXVF9KQ5r61BUPAUMZ7Lf66l64Q==
   dependencies:
-    jest-get-type "^28.0.2"
+    jest-get-type "^29.0.0"
 
-"@jest/expect@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-28.1.2.tgz#0b25acedff46e1e1e5606285306c8a399c12534f"
-  integrity sha512-HBzyZBeFBiOelNbBKN0pilWbbrGvwDUwAqMC46NVJmWm8AVkuE58NbG1s7DR4cxFt4U5cVLxofAoHxgvC5MyOw==
+"@jest/expect@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.0.3.tgz#9dc7c46354eeb7a348d73881fba6402f5fdb2c30"
+  integrity sha512-6W7K+fsI23FQ01H/BWccPyDZFrnU9QlzDcKOjrNVU5L8yUORFAJJIpmyxWPW70+X624KUNqzZwPThPMX28aXEQ==
   dependencies:
-    expect "^28.1.1"
-    jest-snapshot "^28.1.2"
+    expect "^29.0.3"
+    jest-snapshot "^29.0.3"
 
-"@jest/fake-timers@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-28.1.2.tgz#d49e8ee4e02ba85a6e844a52a5e7c59c23e3b76f"
-  integrity sha512-xSYEI7Y0D5FbZN2LsCUj/EKRR1zfQYmGuAUVh6xTqhx7V5JhjgMcK5Pa0iR6WIk0GXiHDe0Ke4A+yERKE9saqg==
+"@jest/fake-timers@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.0.3.tgz#ad5432639b715d45a86a75c47fd75019bc36b22c"
+  integrity sha512-tmbUIo03x0TdtcZCESQ0oQSakPCpo7+s6+9mU19dd71MptkP4zCwoeZqna23//pgbhtT1Wq02VmA9Z9cNtvtCQ==
   dependencies:
-    "@jest/types" "^28.1.1"
+    "@jest/types" "^29.0.3"
     "@sinonjs/fake-timers" "^9.1.2"
     "@types/node" "*"
-    jest-message-util "^28.1.1"
-    jest-mock "^28.1.1"
-    jest-util "^28.1.1"
+    jest-message-util "^29.0.3"
+    jest-mock "^29.0.3"
+    jest-util "^29.0.3"
 
-"@jest/globals@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-28.1.2.tgz#92fab296e337c7309c25e4202fb724f62249d83f"
-  integrity sha512-cz0lkJVDOtDaYhvT3Fv2U1B6FtBnV+OpEyJCzTHM1fdoTsU4QNLAt/H4RkiwEUU+dL4g/MFsoTuHeT2pvbo4Hg==
+"@jest/globals@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.0.3.tgz#681950c430fdc13ff9aa89b2d8d572ac0e4a1bf5"
+  integrity sha512-YqGHT65rFY2siPIHHFjuCGUsbzRjdqkwbat+Of6DmYRg5shIXXrLdZoVE/+TJ9O1dsKsFmYhU58JvIbZRU1Z9w==
   dependencies:
-    "@jest/environment" "^28.1.2"
-    "@jest/expect" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/environment" "^29.0.3"
+    "@jest/expect" "^29.0.3"
+    "@jest/types" "^29.0.3"
+    jest-mock "^29.0.3"
 
-"@jest/reporters@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-28.1.2.tgz#0327be4ce4d0d9ae49e7908656f89669d0c2a260"
-  integrity sha512-/whGLhiwAqeCTmQEouSigUZJPVl7sW8V26EiboImL+UyXznnr1a03/YZ2BX8OlFw0n+Zlwu+EZAITZtaeRTxyA==
+"@jest/reporters@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.0.3.tgz#735f110e08b44b38729d8dbbb74063bdf5aba8a5"
+  integrity sha512-3+QU3d4aiyOWfmk1obDerie4XNCaD5Xo1IlKNde2yGEi02WQD+ZQD0i5Hgqm1e73sMV7kw6pMlCnprtEwEVwxw==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^28.1.1"
-    "@jest/test-result" "^28.1.1"
-    "@jest/transform" "^28.1.2"
-    "@jest/types" "^28.1.1"
-    "@jridgewell/trace-mapping" "^0.3.13"
+    "@jest/console" "^29.0.3"
+    "@jest/test-result" "^29.0.3"
+    "@jest/transform" "^29.0.3"
+    "@jest/types" "^29.0.3"
+    "@jridgewell/trace-mapping" "^0.3.15"
     "@types/node" "*"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
@@ -566,90 +588,78 @@
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.1.3"
-    jest-message-util "^28.1.1"
-    jest-util "^28.1.1"
-    jest-worker "^28.1.1"
+    jest-message-util "^29.0.3"
+    jest-util "^29.0.3"
+    jest-worker "^29.0.3"
     slash "^3.0.0"
     string-length "^4.0.1"
     strip-ansi "^6.0.0"
     terminal-link "^2.0.0"
     v8-to-istanbul "^9.0.1"
 
-"@jest/schemas@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.0.2.tgz#08c30df6a8d07eafea0aef9fb222c5e26d72e613"
-  integrity sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==
+"@jest/schemas@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.0.0.tgz#5f47f5994dd4ef067fb7b4188ceac45f77fe952a"
+  integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
   dependencies:
-    "@sinclair/typebox" "^0.23.3"
+    "@sinclair/typebox" "^0.24.1"
 
-"@jest/source-map@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-28.1.2.tgz#7fe832b172b497d6663cdff6c13b0a920e139e24"
-  integrity sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==
+"@jest/source-map@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.0.0.tgz#f8d1518298089f8ae624e442bbb6eb870ee7783c"
+  integrity sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.13"
+    "@jridgewell/trace-mapping" "^0.3.15"
     callsites "^3.0.0"
     graceful-fs "^4.2.9"
 
-"@jest/test-result@^28.1.1":
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-28.1.1.tgz#c6f18d1bbb01aa88925dd687872a75f8414b317a"
-  integrity sha512-hPmkugBktqL6rRzwWAtp1JtYT4VHwv8OQ+9lE5Gymj6dHzubI/oJHMUpPOt8NrdVWSrz9S7bHjJUmv2ggFoUNQ==
+"@jest/test-result@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.0.3.tgz#b03d8ef4c58be84cd5d5d3b24d4b4c8cabbf2746"
+  integrity sha512-vViVnQjCgTmbhDKEonKJPtcFe9G/CJO4/Np4XwYJah+lF2oI7KKeRp8t1dFvv44wN2NdbDb/qC6pi++Vpp0Dlg==
   dependencies:
-    "@jest/console" "^28.1.1"
-    "@jest/types" "^28.1.1"
+    "@jest/console" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^28.1.1":
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-28.1.1.tgz#f594ee2331df75000afe0d1ae3237630ecec732e"
-  integrity sha512-nuL+dNSVMcWB7OOtgb0EGH5AjO4UBCt68SLP08rwmC+iRhyuJWS9MtZ/MpipxFwKAlHFftbMsydXqWre8B0+XA==
+"@jest/test-sequencer@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.0.3.tgz#0681061ad21fb8e293b49c4fdf7e631ca79240ba"
+  integrity sha512-Hf4+xYSWZdxTNnhDykr8JBs0yBN/nxOXyUQWfotBUqqy0LF9vzcFB0jm/EDNZCx587znLWTIgxcokW7WeZMobQ==
   dependencies:
-    "@jest/test-result" "^28.1.1"
+    "@jest/test-result" "^29.0.3"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.1.1"
+    jest-haste-map "^29.0.3"
     slash "^3.0.0"
 
-"@jest/transform@^28.1.2":
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-28.1.2.tgz#b367962c53fd53821269bde050ce373e111327c1"
-  integrity sha512-3o+lKF6iweLeJFHBlMJysdaPbpoMmtbHEFsjzSv37HIq/wWt5ijTeO2Yf7MO5yyczCopD507cNwNLeX8Y/CuIg==
+"@jest/transform@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.0.3.tgz#9eb1fed2072a0354f190569807d1250572fb0970"
+  integrity sha512-C5ihFTRYaGDbi/xbRQRdbo5ddGtI4VSpmL6AIcZxdhwLbXMa7PcXxxqyI91vGOFHnn5aVM3WYnYKCHEqmLVGzg==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/types" "^28.1.1"
-    "@jridgewell/trace-mapping" "^0.3.13"
+    "@jest/types" "^29.0.3"
+    "@jridgewell/trace-mapping" "^0.3.15"
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.1.1"
-    jest-regex-util "^28.0.2"
-    jest-util "^28.1.1"
+    jest-haste-map "^29.0.3"
+    jest-regex-util "^29.0.0"
+    jest-util "^29.0.3"
     micromatch "^4.0.4"
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
 
-"@jest/types@^28.1.0":
-  version "28.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.0.tgz#508327a89976cbf9bd3e1cc74641a29fd7dfd519"
-  integrity sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==
+"@jest/types@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.0.3.tgz#0be78fdddb1a35aeb2041074e55b860561c8ef63"
+  integrity sha512-coBJmOQvurXjN1Hh5PzF7cmsod0zLIOXpP8KD161mqNlroMhLcwpODiEzi7ZsRl5Z/AIuxpeNm8DCl43F4kz8A==
   dependencies:
-    "@jest/schemas" "^28.0.2"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.8"
-    chalk "^4.0.0"
-
-"@jest/types@^28.1.1":
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.1.tgz#d059bbc80e6da6eda9f081f293299348bd78ee0b"
-  integrity sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==
-  dependencies:
-    "@jest/schemas" "^28.0.2"
+    "@jest/schemas" "^29.0.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -701,10 +711,18 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
   integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.15":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
+  integrity sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -759,10 +777,10 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
-"@sinclair/typebox@^0.23.3":
-  version "0.23.5"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
-  integrity sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==
+"@sinclair/typebox@^0.24.1":
+  version "0.24.41"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.41.tgz#45470b8bae32a28f1e0501066d0bacbd8b772804"
+  integrity sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -811,10 +829,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/eslint@^8.4.5":
-  version "8.4.5"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.5.tgz#acdfb7dd36b91cc5d812d7c093811a8f3d9b31e4"
-  integrity sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==
+"@types/eslint@^8.4.6":
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.6.tgz#7976f054c1bccfcf514bff0564c0c41df5c08207"
+  integrity sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -855,13 +873,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^28.1.4":
-  version "28.1.4"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.4.tgz#a11ee6c8fd0b52c19c9c18138b78bbcc201dad5a"
-  integrity sha512-telv6G5N7zRJiLcI3Rs3o+ipZ28EnE+7EvF0pSrt2pZOMnAVI/f+6/LucDxOvcBcTeTL3JMF744BbVQAVBUQRA==
+"@types/jest@^29.0.2":
+  version "29.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.0.2.tgz#05dcb2d78d2fcc444be89f95b7389f2c3601d336"
+  integrity sha512-TaklkwSEtvwJpleiKBHgEBySIQlcZ08gYP/s5wdtdLnjz9uxjnDd7U+Y0JWACebkqBc+jtbol2PEtEW0wQV2zQ==
   dependencies:
-    jest-matcher-utils "^28.0.0"
-    pretty-format "^28.0.0"
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/json-schema@*":
   version "7.0.9"
@@ -883,10 +901,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
-"@types/node@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
-  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
+"@types/node@^18.7.18":
+  version "18.7.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
+  integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
 
 "@types/object-path@^0.11.1":
   version "0.11.1"
@@ -932,14 +950,14 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.3.tgz#2f293e56b73c4f281e48d253af4a17f21a55d54c"
-  integrity sha512-QEgE1uahnDbWEkZlidq7uKB630ny1NN8KbLPmznX+8hYsYpoV1/quG1Nzvs141FVuumuS7O0EpqYw3RB4AVzRg==
+"@typescript-eslint/eslint-plugin@^5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz#5ccdd5d9004120f28fc6e717fb4b5c9bddcfbc04"
+  integrity sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.30.3"
-    "@typescript-eslint/type-utils" "5.30.3"
-    "@typescript-eslint/utils" "5.30.3"
+    "@typescript-eslint/scope-manager" "5.37.0"
+    "@typescript-eslint/type-utils" "5.37.0"
+    "@typescript-eslint/utils" "5.37.0"
     debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
     ignore "^5.2.0"
@@ -947,14 +965,14 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.30.3.tgz#d288c7dbeadf22403112c773dd53e0700f6dd6d5"
-  integrity sha512-ddwGEPC3E49DduAUC8UThQafHRE5uc1NE8jdOgl+w8/NrYF50MJQNeD3u4JZrqAXdY9rJz0CdQ9HpNME20CzkA==
+"@typescript-eslint/parser@^5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.37.0.tgz#c382077973f3a4ede7453fb14cadcad3970cbf3b"
+  integrity sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.30.3"
-    "@typescript-eslint/types" "5.30.3"
-    "@typescript-eslint/typescript-estree" "5.30.3"
+    "@typescript-eslint/scope-manager" "5.37.0"
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/typescript-estree" "5.37.0"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.25.0":
@@ -965,20 +983,21 @@
     "@typescript-eslint/types" "5.25.0"
     "@typescript-eslint/visitor-keys" "5.25.0"
 
-"@typescript-eslint/scope-manager@5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.3.tgz#de7edb0b59efd71975a82cbf3f1b97c5c90769f0"
-  integrity sha512-yVJIIUXeo/vv6Alj6lKBvsqnRs5hcxUpN3Dg3aD9Zv6r7p6Nn106jJcr5rnpRHAReEb/aMI2RWrt3JmL17eCVA==
+"@typescript-eslint/scope-manager@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz#044980e4f1516a774a418dafe701a483a6c9f9ca"
+  integrity sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==
   dependencies:
-    "@typescript-eslint/types" "5.30.3"
-    "@typescript-eslint/visitor-keys" "5.30.3"
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/visitor-keys" "5.37.0"
 
-"@typescript-eslint/type-utils@5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.30.3.tgz#1bb4efcfc8de38086d50096709b2cccf72684515"
-  integrity sha512-IIzakE7OXOqdwPaXhRiPnaZ8OuJJYBLufOffd9fqzkI4IMFIYq8KC7bghdnF7QUJTirURRErQFrJ/w5UpwIqaw==
+"@typescript-eslint/type-utils@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz#43ed2f567ada49d7e33a6e4b6f9babd060445fe5"
+  integrity sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==
   dependencies:
-    "@typescript-eslint/utils" "5.30.3"
+    "@typescript-eslint/typescript-estree" "5.37.0"
+    "@typescript-eslint/utils" "5.37.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
@@ -987,10 +1006,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.25.0.tgz#dee51b1855788b24a2eceeae54e4adb89b088dd8"
   integrity sha512-7fWqfxr0KNHj75PFqlGX24gWjdV/FDBABXL5dyvBOWHpACGyveok8Uj4ipPX/1fGU63fBkzSIycEje4XsOxUFA==
 
-"@typescript-eslint/types@5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.3.tgz#8ef6313dcec2e297b167dd25ef363e36857c49ff"
-  integrity sha512-vshU3pjSTgBPNgfd55JLYngHkXuwQP68fxYFUAg1Uq+JrR3xG/XjvL9Dmv28CpOERtqwkaR4QQ3mD0NLZcE2Xw==
+"@typescript-eslint/types@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.37.0.tgz#09e4870a5f3af7af3f84e08d792644a87d232261"
+  integrity sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==
 
 "@typescript-eslint/typescript-estree@5.25.0":
   version "5.25.0"
@@ -1005,28 +1024,28 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.3.tgz#d5ff918499dd56039864c157a898b1322d7bff8c"
-  integrity sha512-jqVh5N9AJx6+7yRgoA+ZelAFrHezgI9pzI9giv7s84DDOmtpFwTgURcpICDHyz9x6vAeOu91iACZ4dBTVfzIyA==
+"@typescript-eslint/typescript-estree@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz#956dcf5c98363bcb97bdd5463a0a86072ff79355"
+  integrity sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==
   dependencies:
-    "@typescript-eslint/types" "5.30.3"
-    "@typescript-eslint/visitor-keys" "5.30.3"
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/visitor-keys" "5.37.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.3.tgz#be2ebaef73e5610c866c4f29ed33669acc89e3fc"
-  integrity sha512-OEaBXGxxdIy35H+jyXfYAMQ66KMJczK9hEhL3gR6IRbWe5PyK+bPDC9zbQNVII6rNFTfF/Mse0z21NlEU+vOMw==
+"@typescript-eslint/utils@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.37.0.tgz#7784cb8e91390c4f90ccaffd24a0cf9874df81b2"
+  integrity sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.30.3"
-    "@typescript-eslint/types" "5.30.3"
-    "@typescript-eslint/typescript-estree" "5.30.3"
+    "@typescript-eslint/scope-manager" "5.37.0"
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/typescript-estree" "5.37.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -1050,12 +1069,12 @@
     "@typescript-eslint/types" "5.25.0"
     eslint-visitor-keys "^3.3.0"
 
-"@typescript-eslint/visitor-keys@5.30.3":
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.3.tgz#2c5f7a16c36748d1c51ea5a9c29bfb64780ce466"
-  integrity sha512-ep2xtHOhnSRt6fDP9DSSxrA/FqZhdMF7/Y9fYsxrKss2uWJMbzJyBJ/We1fKc786BJ10pHwrzUlhvpz8i7XzBg==
+"@typescript-eslint/visitor-keys@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz#7b72dd343295ea11e89b624995abc7103c554eee"
+  integrity sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==
   dependencies:
-    "@typescript-eslint/types" "5.30.3"
+    "@typescript-eslint/types" "5.37.0"
     eslint-visitor-keys "^3.3.0"
 
 "@wessberg/stringutil@^1.0.19":
@@ -1068,10 +1087,15 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.5.0, acorn@^8.7.1:
+acorn@^8.5.0:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
+
+acorn@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
@@ -1171,15 +1195,15 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-babel-jest@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-28.1.2.tgz#2b37fb81439f14d34d8b2cc4a4bd7efabf9acbfe"
-  integrity sha512-pfmoo6sh4L/+5/G2OOfQrGJgvH7fTa1oChnuYH2G/6gA+JwDvO8PELwvwnofKBMNrQsam0Wy/Rw+QSrBNewq2Q==
+babel-jest@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.0.3.tgz#64e156a47a77588db6a669a88dedff27ed6e260f"
+  integrity sha512-ApPyHSOhS/sVzwUOQIWJmdvDhBsMG01HX9z7ogtkp1TToHGGUWFlnXJUIzCgKPSfiYLn3ibipCYzsKSURHEwLg==
   dependencies:
-    "@jest/transform" "^28.1.2"
+    "@jest/transform" "^29.0.3"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
-    babel-preset-jest "^28.1.1"
+    babel-preset-jest "^29.0.2"
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     slash "^3.0.0"
@@ -1195,10 +1219,10 @@ babel-plugin-istanbul@^6.1.1:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.1.tgz#5e055cdcc47894f28341f87f5e35aad2df680b11"
-  integrity sha512-NovGCy5Hn25uMJSAU8FaHqzs13cFoOI4lhIujiepssjCKRsAo3TA734RDWSGxuFTsUJXerYOqQQodlxgmtqbzw==
+babel-plugin-jest-hoist@^29.0.2:
+  version "29.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz#ae61483a829a021b146c016c6ad39b8bcc37c2c8"
+  integrity sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -1223,12 +1247,12 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
-babel-preset-jest@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-28.1.1.tgz#5b6e5e69f963eb2d70f739c607b8f723c0ee75e4"
-  integrity sha512-FCq9Oud0ReTeWtcneYf/48981aTfXYuB9gbU4rBNNJVBSQ6ssv7E6v/qvbBxtOWwZFXjLZwpg+W3q7J6vhH25g==
+babel-preset-jest@^29.0.2:
+  version "29.0.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz#e14a7124e22b161551818d89e5bdcfb3b2b0eac7"
+  integrity sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==
   dependencies:
-    babel-plugin-jest-hoist "^28.1.1"
+    babel-plugin-jest-hoist "^29.0.2"
     babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
@@ -1560,10 +1584,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
-  integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
+diff-sequences@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.0.0.tgz#bae49972ef3933556bcb0800b72e8579d19d9e4f"
+  integrity sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1644,10 +1668,10 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-plugin-jest@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.5.3.tgz#a3ceeaf4a757878342b8b00eca92379b246e5505"
-  integrity sha512-sICclUqJQnR1bFRZGLN2jnSVsYOsmPYYnroGCIMVSvTS3y8XR3yjzy1EcTQmk6typ5pRgyIWzbjqxK6cZHEZuQ==
+eslint-plugin-jest@^27.0.4:
+  version "27.0.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.0.4.tgz#ab9c7b3f48bfade4762c24c415a5d9bbc0174a61"
+  integrity sha512-BuvY78pHMpMJ6Cio7sKg6jrqEcnRYPUc4Nlihku4vKx3FjlmMINSX4vcYokZIe+8TKcyr1aI5Kq7vYwgJNdQSA==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
@@ -1684,13 +1708,15 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@^8.19.0:
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.19.0.tgz#7342a3cbc4fbc5c106a1eefe0fd0b50b6b1a7d28"
-  integrity sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==
+eslint@^8.23.1:
+  version "8.23.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.23.1.tgz#cfd7b3f7fdd07db8d16b4ac0516a29c8d8dca5dc"
+  integrity sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==
   dependencies:
-    "@eslint/eslintrc" "^1.3.0"
-    "@humanwhocodes/config-array" "^0.9.2"
+    "@eslint/eslintrc" "^1.3.2"
+    "@humanwhocodes/config-array" "^0.10.4"
+    "@humanwhocodes/gitignore-to-minimatch" "^1.0.2"
+    "@humanwhocodes/module-importer" "^1.0.1"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -1700,18 +1726,21 @@ eslint@^8.19.0:
     eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
     eslint-visitor-keys "^3.3.0"
-    espree "^9.3.2"
+    espree "^9.4.0"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
-    functional-red-black-tree "^1.0.1"
+    find-up "^5.0.0"
     glob-parent "^6.0.1"
     globals "^13.15.0"
+    globby "^11.1.0"
+    grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
+    js-sdsl "^4.1.4"
     js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
@@ -1723,14 +1752,13 @@ eslint@^8.19.0:
     strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
 
-espree@^9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
-  integrity sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==
+espree@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.0.tgz#cd4bc3d6e9336c433265fc0aa016fc1aaf182f8a"
+  integrity sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==
   dependencies:
-    acorn "^8.7.1"
+    acorn "^8.8.0"
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
@@ -1798,16 +1826,16 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expect@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-28.1.1.tgz#ca6fff65f6517cf7220c2e805a49c19aea30b420"
-  integrity sha512-/AANEwGL0tWBwzLNOvO0yUdy2D52jVdNXppOqswC49sxMN2cPWsGCQdzuIf9tj6hHoBQzNvx75JUYuQAckPo3w==
+expect@^29.0.0, expect@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.0.3.tgz#6be65ddb945202f143c4e07c083f4f39f3bd326f"
+  integrity sha512-t8l5DTws3212VbmPL+tBFXhjRHLmctHB0oQbL8eUc6S7NzZtYUhycrFO9mkxA0ZUC6FAWdNi7JchJSkODtcu1Q==
   dependencies:
-    "@jest/expect-utils" "^28.1.1"
-    jest-get-type "^28.0.2"
-    jest-matcher-utils "^28.1.1"
-    jest-message-util "^28.1.1"
-    jest-util "^28.1.1"
+    "@jest/expect-utils" "^29.0.3"
+    jest-get-type "^29.0.0"
+    jest-matcher-utils "^29.0.3"
+    jest-message-util "^29.0.3"
+    jest-util "^29.0.3"
 
 extend@~3.0.2:
   version "3.0.2"
@@ -1840,7 +1868,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2022,6 +2050,11 @@ graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -2222,188 +2255,188 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-changed-files@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-28.0.2.tgz#7d7810660a5bd043af9e9cfbe4d58adb05e91531"
-  integrity sha512-QX9u+5I2s54ZnGoMEjiM2WeBvJR2J7w/8ZUmH2um/WLAuGAYFQcsVXY9+1YL6k0H/AGUdH8pXUAv6erDqEsvIA==
+jest-changed-files@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.0.0.tgz#aa238eae42d9372a413dd9a8dadc91ca1806dce0"
+  integrity sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==
   dependencies:
     execa "^5.0.0"
-    throat "^6.0.1"
+    p-limit "^3.1.0"
 
-jest-circus@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-28.1.2.tgz#0d5a5623eccb244efe87d1edc365696e4fcf80ce"
-  integrity sha512-E2vdPIJG5/69EMpslFhaA46WkcrN74LI5V/cSJ59L7uS8UNoXbzTxmwhpi9XrIL3zqvMt5T0pl5k2l2u2GwBNQ==
+jest-circus@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.0.3.tgz#90faebc90295291cfc636b27dbd82e3bfb9e7a48"
+  integrity sha512-QeGzagC6Hw5pP+df1+aoF8+FBSgkPmraC1UdkeunWh0jmrp7wC0Hr6umdUAOELBQmxtKAOMNC3KAdjmCds92Zg==
   dependencies:
-    "@jest/environment" "^28.1.2"
-    "@jest/expect" "^28.1.2"
-    "@jest/test-result" "^28.1.1"
-    "@jest/types" "^28.1.1"
+    "@jest/environment" "^29.0.3"
+    "@jest/expect" "^29.0.3"
+    "@jest/test-result" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
     dedent "^0.7.0"
     is-generator-fn "^2.0.0"
-    jest-each "^28.1.1"
-    jest-matcher-utils "^28.1.1"
-    jest-message-util "^28.1.1"
-    jest-runtime "^28.1.2"
-    jest-snapshot "^28.1.2"
-    jest-util "^28.1.1"
-    pretty-format "^28.1.1"
+    jest-each "^29.0.3"
+    jest-matcher-utils "^29.0.3"
+    jest-message-util "^29.0.3"
+    jest-runtime "^29.0.3"
+    jest-snapshot "^29.0.3"
+    jest-util "^29.0.3"
+    p-limit "^3.1.0"
+    pretty-format "^29.0.3"
     slash "^3.0.0"
     stack-utils "^2.0.3"
-    throat "^6.0.1"
 
-jest-cli@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-28.1.2.tgz#b89012e5bad14135e71b1628b85475d3773a1bbc"
-  integrity sha512-l6eoi5Do/IJUXAFL9qRmDiFpBeEJAnjJb1dcd9i/VWfVWbp3mJhuH50dNtX67Ali4Ecvt4eBkWb4hXhPHkAZTw==
+jest-cli@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.0.3.tgz#fd8f0ef363a7a3d9c53ef62e0651f18eeffa77b9"
+  integrity sha512-aUy9Gd/Kut1z80eBzG10jAn6BgS3BoBbXyv+uXEqBJ8wnnuZ5RpNfARoskSrTIy1GY4a8f32YGuCMwibtkl9CQ==
   dependencies:
-    "@jest/core" "^28.1.2"
-    "@jest/test-result" "^28.1.1"
-    "@jest/types" "^28.1.1"
+    "@jest/core" "^29.0.3"
+    "@jest/test-result" "^29.0.3"
+    "@jest/types" "^29.0.3"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.9"
     import-local "^3.0.2"
-    jest-config "^28.1.2"
-    jest-util "^28.1.1"
-    jest-validate "^28.1.1"
+    jest-config "^29.0.3"
+    jest-util "^29.0.3"
+    jest-validate "^29.0.3"
     prompts "^2.0.1"
     yargs "^17.3.1"
 
-jest-config@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-28.1.2.tgz#ba00ad30caf62286c86e7c1099e915218a0ac8c6"
-  integrity sha512-g6EfeRqddVbjPVBVY4JWpUY4IvQoFRIZcv4V36QkqzE0IGhEC/VkugFeBMAeUE7PRgC8KJF0yvJNDeQRbamEVA==
+jest-config@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.0.3.tgz#c2e52a8f5adbd18de79f99532d8332a19e232f13"
+  integrity sha512-U5qkc82HHVYe3fNu2CRXLN4g761Na26rWKf7CjM8LlZB3In1jadEkZdMwsE37rd9RSPV0NfYaCjHdk/gu3v+Ew==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/test-sequencer" "^28.1.1"
-    "@jest/types" "^28.1.1"
-    babel-jest "^28.1.2"
+    "@jest/test-sequencer" "^29.0.3"
+    "@jest/types" "^29.0.3"
+    babel-jest "^29.0.3"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
-    jest-circus "^28.1.2"
-    jest-environment-node "^28.1.2"
-    jest-get-type "^28.0.2"
-    jest-regex-util "^28.0.2"
-    jest-resolve "^28.1.1"
-    jest-runner "^28.1.2"
-    jest-util "^28.1.1"
-    jest-validate "^28.1.1"
+    jest-circus "^29.0.3"
+    jest-environment-node "^29.0.3"
+    jest-get-type "^29.0.0"
+    jest-regex-util "^29.0.0"
+    jest-resolve "^29.0.3"
+    jest-runner "^29.0.3"
+    jest-util "^29.0.3"
+    jest-validate "^29.0.3"
     micromatch "^4.0.4"
     parse-json "^5.2.0"
-    pretty-format "^28.1.1"
+    pretty-format "^29.0.3"
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-28.1.1.tgz#1a3eedfd81ae79810931c63a1d0f201b9120106c"
-  integrity sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==
+jest-diff@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.0.3.tgz#41cc02409ad1458ae1bf7684129a3da2856341ac"
+  integrity sha512-+X/AIF5G/vX9fWK+Db9bi9BQas7M9oBME7egU7psbn4jlszLFCu0dW63UgeE6cs/GANq4fLaT+8sGHQQ0eCUfg==
   dependencies:
     chalk "^4.0.0"
-    diff-sequences "^28.1.1"
-    jest-get-type "^28.0.2"
-    pretty-format "^28.1.1"
+    diff-sequences "^29.0.0"
+    jest-get-type "^29.0.0"
+    pretty-format "^29.0.3"
 
-jest-docblock@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-28.1.1.tgz#6f515c3bf841516d82ecd57a62eed9204c2f42a8"
-  integrity sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==
+jest-docblock@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.0.0.tgz#3151bcc45ed7f5a8af4884dcc049aee699b4ceae"
+  integrity sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-28.1.1.tgz#ba5238dacf4f31d9fe23ddc2c44c01e7c23885c4"
-  integrity sha512-A042rqh17ZvEhRceDMi784ppoXR7MWGDEKTXEZXb4svt0eShMZvijGxzKsx+yIjeE8QYmHPrnHiTSQVhN4nqaw==
+jest-each@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.0.3.tgz#7ef3157580b15a609d7ef663dd4fc9b07f4e1299"
+  integrity sha512-wILhZfESURHHBNvPMJ0lZlYZrvOQJxAo3wNHi+ycr90V7M+uGR9Gh4+4a/BmaZF0XTyZsk4OiYEf3GJN7Ltqzg==
   dependencies:
-    "@jest/types" "^28.1.1"
+    "@jest/types" "^29.0.3"
     chalk "^4.0.0"
-    jest-get-type "^28.0.2"
-    jest-util "^28.1.1"
-    pretty-format "^28.1.1"
+    jest-get-type "^29.0.0"
+    jest-util "^29.0.3"
+    pretty-format "^29.0.3"
 
-jest-environment-node@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-28.1.2.tgz#3e2eb47f6d173b0648d5f7c717cb1c26651d5c8a"
-  integrity sha512-oYsZz9Qw27XKmOgTtnl0jW7VplJkN2oeof+SwAwKFQacq3CLlG9u4kTGuuLWfvu3J7bVutWlrbEQMOCL/jughw==
+jest-environment-node@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.0.3.tgz#293804b1e0fa5f0e354dacbe510655caa478a3b2"
+  integrity sha512-cdZqRCnmIlTXC+9vtvmfiY/40Cj6s2T0czXuq1whvQdmpzAnj4sbqVYuZ4zFHk766xTTJ+Ij3uUqkk8KCfXoyg==
   dependencies:
-    "@jest/environment" "^28.1.2"
-    "@jest/fake-timers" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/environment" "^29.0.3"
+    "@jest/fake-timers" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
-    jest-mock "^28.1.1"
-    jest-util "^28.1.1"
+    jest-mock "^29.0.3"
+    jest-util "^29.0.3"
 
-jest-get-type@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
-  integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
+jest-get-type@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.0.0.tgz#843f6c50a1b778f7325df1129a0fd7aa713aef80"
+  integrity sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==
 
-jest-haste-map@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-28.1.1.tgz#471685f1acd365a9394745bb97c8fc16289adca3"
-  integrity sha512-ZrRSE2o3Ezh7sb1KmeLEZRZ4mgufbrMwolcFHNRSjKZhpLa8TdooXOOFlSwoUzlbVs1t0l7upVRW2K7RWGHzbQ==
+jest-haste-map@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.0.3.tgz#d7f3f7180f558d760eacc5184aac5a67f20ef939"
+  integrity sha512-uMqR99+GuBHo0RjRhOE4iA6LmsxEwRdgiIAQgMU/wdT2XebsLDz5obIwLZm/Psj+GwSEQhw9AfAVKGYbh2G55A==
   dependencies:
-    "@jest/types" "^28.1.1"
+    "@jest/types" "^29.0.3"
     "@types/graceful-fs" "^4.1.3"
     "@types/node" "*"
     anymatch "^3.0.3"
     fb-watchman "^2.0.0"
     graceful-fs "^4.2.9"
-    jest-regex-util "^28.0.2"
-    jest-util "^28.1.1"
-    jest-worker "^28.1.1"
+    jest-regex-util "^29.0.0"
+    jest-util "^29.0.3"
+    jest-worker "^29.0.3"
     micromatch "^4.0.4"
     walker "^1.0.8"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-leak-detector@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-28.1.1.tgz#537f37afd610a4b3f4cab15e06baf60484548efb"
-  integrity sha512-4jvs8V8kLbAaotE+wFR7vfUGf603cwYtFf1/PYEsyX2BAjSzj8hQSVTP6OWzseTl0xL6dyHuKs2JAks7Pfubmw==
+jest-leak-detector@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.0.3.tgz#e85cf3391106a7a250850b6766b508bfe9c7bc6f"
+  integrity sha512-YfW/G63dAuiuQ3QmQlh8hnqLDe25WFY3eQhuc/Ev1AGmkw5zREblTh7TCSKLoheyggu6G9gxO2hY8p9o6xbaRQ==
   dependencies:
-    jest-get-type "^28.0.2"
-    pretty-format "^28.1.1"
+    jest-get-type "^29.0.0"
+    pretty-format "^29.0.3"
 
-jest-matcher-utils@^28.0.0, jest-matcher-utils@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz#a7c4653c2b782ec96796eb3088060720f1e29304"
-  integrity sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==
+jest-matcher-utils@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.0.3.tgz#b8305fd3f9e27cdbc210b21fc7dbba92d4e54560"
+  integrity sha512-RsR1+cZ6p1hDV4GSCQTg+9qjeotQCgkaleIKLK7dm+U4V/H2bWedU3RAtLm8+mANzZ7eDV33dMar4pejd7047w==
   dependencies:
     chalk "^4.0.0"
-    jest-diff "^28.1.1"
-    jest-get-type "^28.0.2"
-    pretty-format "^28.1.1"
+    jest-diff "^29.0.3"
+    jest-get-type "^29.0.0"
+    pretty-format "^29.0.3"
 
-jest-message-util@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-28.1.1.tgz#60aa0b475cfc08c8a9363ed2fb9108514dd9ab89"
-  integrity sha512-xoDOOT66fLfmTRiqkoLIU7v42mal/SqwDKvfmfiWAdJMSJiU+ozgluO7KbvoAgiwIrrGZsV7viETjc8GNrA/IQ==
+jest-message-util@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.0.3.tgz#f0254e1ffad21890c78355726202cc91d0a40ea8"
+  integrity sha512-7T8JiUTtDfppojosORAflABfLsLKMLkBHSWkjNQrjIltGoDzNGn7wEPOSfjqYAGTYME65esQzMJxGDjuLBKdOg==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^28.1.1"
+    "@jest/types" "^29.0.3"
     "@types/stack-utils" "^2.0.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     micromatch "^4.0.4"
-    pretty-format "^28.1.1"
+    pretty-format "^29.0.3"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-28.1.1.tgz#37903d269427fa1ef5b2447be874e1c62a39a371"
-  integrity sha512-bDCb0FjfsmKweAvE09dZT59IMkzgN0fYBH6t5S45NoJfd2DHkS3ySG2K+hucortryhO3fVuXdlxWcbtIuV/Skw==
+jest-mock@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.0.3.tgz#4f0093f6a9cb2ffdb9c44a07a3912f0c098c8de9"
+  integrity sha512-ort9pYowltbcrCVR43wdlqfAiFJXBx8l4uJDsD8U72LgBcetvEp+Qxj1W9ZYgMRoeAo+ov5cnAGF2B6+Oth+ww==
   dependencies:
-    "@jest/types" "^28.1.1"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.2:
@@ -2411,166 +2444,155 @@ jest-pnp-resolver@^1.2.2:
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
-jest-regex-util@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-28.0.2.tgz#afdc377a3b25fb6e80825adcf76c854e5bf47ead"
-  integrity sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==
+jest-regex-util@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.0.0.tgz#b442987f688289df8eb6c16fa8df488b4cd007de"
+  integrity sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==
 
-jest-resolve-dependencies@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.2.tgz#ca528858e0c6642d5a1dda8fc7cda10230c275bc"
-  integrity sha512-OXw4vbOZuyRTBi3tapWBqdyodU+T33ww5cPZORuTWkg+Y8lmsxQlVu3MWtJh6NMlKRTHQetF96yGPv01Ye7Mbg==
+jest-resolve-dependencies@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.0.3.tgz#f23a54295efc6374b86b198cf8efed5606d6b762"
+  integrity sha512-KzuBnXqNvbuCdoJpv8EanbIGObk7vUBNt/PwQPPx2aMhlv/jaXpUJsqWYRpP/0a50faMBY7WFFP8S3/CCzwfDw==
   dependencies:
-    jest-regex-util "^28.0.2"
-    jest-snapshot "^28.1.2"
+    jest-regex-util "^29.0.0"
+    jest-snapshot "^29.0.3"
 
-jest-resolve@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-28.1.1.tgz#bc2eaf384abdcc1aaf3ba7c50d1adf01e59095e5"
-  integrity sha512-/d1UbyUkf9nvsgdBildLe6LAD4DalgkgZcKd0nZ8XUGPyA/7fsnaQIlKVnDiuUXv/IeZhPEDrRJubVSulxrShA==
+jest-resolve@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.0.3.tgz#329a3431e3b9eb6629a2cd483e9bed95b26827b9"
+  integrity sha512-toVkia85Y/BPAjJasTC9zIPY6MmVXQPtrCk8SmiheC4MwVFE/CMFlOtMN6jrwPMC6TtNh8+sTMllasFeu1wMPg==
   dependencies:
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.1.1"
+    jest-haste-map "^29.0.3"
     jest-pnp-resolver "^1.2.2"
-    jest-util "^28.1.1"
-    jest-validate "^28.1.1"
+    jest-util "^29.0.3"
+    jest-validate "^29.0.3"
     resolve "^1.20.0"
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
-jest-runner@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-28.1.2.tgz#f293409592a62234285a71237e38499a3554e350"
-  integrity sha512-6/k3DlAsAEr5VcptCMdhtRhOoYClZQmxnVMZvZ/quvPGRpN7OBQYPIC32tWSgOnbgqLXNs5RAniC+nkdFZpD4A==
+jest-runner@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.0.3.tgz#2e47fe1e8777aea9b8970f37e8f83630b508fb87"
+  integrity sha512-Usu6VlTOZlCZoNuh3b2Tv/yzDpKqtiNAetG9t3kJuHfUyVMNW7ipCCJOUojzKkjPoaN7Bl1f7Buu6PE0sGpQxw==
   dependencies:
-    "@jest/console" "^28.1.1"
-    "@jest/environment" "^28.1.2"
-    "@jest/test-result" "^28.1.1"
-    "@jest/transform" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/console" "^29.0.3"
+    "@jest/environment" "^29.0.3"
+    "@jest/test-result" "^29.0.3"
+    "@jest/transform" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
     chalk "^4.0.0"
     emittery "^0.10.2"
     graceful-fs "^4.2.9"
-    jest-docblock "^28.1.1"
-    jest-environment-node "^28.1.2"
-    jest-haste-map "^28.1.1"
-    jest-leak-detector "^28.1.1"
-    jest-message-util "^28.1.1"
-    jest-resolve "^28.1.1"
-    jest-runtime "^28.1.2"
-    jest-util "^28.1.1"
-    jest-watcher "^28.1.1"
-    jest-worker "^28.1.1"
+    jest-docblock "^29.0.0"
+    jest-environment-node "^29.0.3"
+    jest-haste-map "^29.0.3"
+    jest-leak-detector "^29.0.3"
+    jest-message-util "^29.0.3"
+    jest-resolve "^29.0.3"
+    jest-runtime "^29.0.3"
+    jest-util "^29.0.3"
+    jest-watcher "^29.0.3"
+    jest-worker "^29.0.3"
+    p-limit "^3.1.0"
     source-map-support "0.5.13"
-    throat "^6.0.1"
 
-jest-runtime@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-28.1.2.tgz#d68f34f814a848555a345ceda23289f14d59a688"
-  integrity sha512-i4w93OsWzLOeMXSi9epmakb2+3z0AchZtUQVF1hesBmcQQy4vtaql5YdVe9KexdJaVRyPDw8DoBR0j3lYsZVYw==
+jest-runtime@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.0.3.tgz#5a823ec5902257519556a4e5a71a868e8fd788aa"
+  integrity sha512-12gZXRQ7ozEeEHKTY45a+YLqzNDR/x4c//X6AqwKwKJPpWM8FY4vwn4VQJOcLRS3Nd1fWwgP7LU4SoynhuUMHQ==
   dependencies:
-    "@jest/environment" "^28.1.2"
-    "@jest/fake-timers" "^28.1.2"
-    "@jest/globals" "^28.1.2"
-    "@jest/source-map" "^28.1.2"
-    "@jest/test-result" "^28.1.1"
-    "@jest/transform" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/environment" "^29.0.3"
+    "@jest/fake-timers" "^29.0.3"
+    "@jest/globals" "^29.0.3"
+    "@jest/source-map" "^29.0.0"
+    "@jest/test-result" "^29.0.3"
+    "@jest/transform" "^29.0.3"
+    "@jest/types" "^29.0.3"
+    "@types/node" "*"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
-    execa "^5.0.0"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.1.1"
-    jest-message-util "^28.1.1"
-    jest-mock "^28.1.1"
-    jest-regex-util "^28.0.2"
-    jest-resolve "^28.1.1"
-    jest-snapshot "^28.1.2"
-    jest-util "^28.1.1"
+    jest-haste-map "^29.0.3"
+    jest-message-util "^29.0.3"
+    jest-mock "^29.0.3"
+    jest-regex-util "^29.0.0"
+    jest-resolve "^29.0.3"
+    jest-snapshot "^29.0.3"
+    jest-util "^29.0.3"
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
-jest-snapshot@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-28.1.2.tgz#93d31b87b11b384f5946fe0767541496135f8d52"
-  integrity sha512-wzrieFttZYfLvrCVRJxX+jwML2YTArOUqFpCoSVy1QUapx+LlV9uLbV/mMEhYj4t7aMeE9aSQFHSvV/oNoDAMA==
+jest-snapshot@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.0.3.tgz#0a024706986a915a6eefae74d7343069d2fc8eef"
+  integrity sha512-52q6JChm04U3deq+mkQ7R/7uy7YyfVIrebMi6ZkBoDJ85yEjm/sJwdr1P0LOIEHmpyLlXrxy3QP0Zf5J2kj0ew==
   dependencies:
     "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.3.3"
-    "@jest/expect-utils" "^28.1.1"
-    "@jest/transform" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/expect-utils" "^29.0.3"
+    "@jest/transform" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/babel__traverse" "^7.0.6"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^28.1.1"
+    expect "^29.0.3"
     graceful-fs "^4.2.9"
-    jest-diff "^28.1.1"
-    jest-get-type "^28.0.2"
-    jest-haste-map "^28.1.1"
-    jest-matcher-utils "^28.1.1"
-    jest-message-util "^28.1.1"
-    jest-util "^28.1.1"
+    jest-diff "^29.0.3"
+    jest-get-type "^29.0.0"
+    jest-haste-map "^29.0.3"
+    jest-matcher-utils "^29.0.3"
+    jest-message-util "^29.0.3"
+    jest-util "^29.0.3"
     natural-compare "^1.4.0"
-    pretty-format "^28.1.1"
+    pretty-format "^29.0.3"
     semver "^7.3.5"
 
-jest-util@^28.0.0:
-  version "28.1.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.0.tgz#d54eb83ad77e1dd441408738c5a5043642823be5"
-  integrity sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==
+jest-util@^29.0.0, jest-util@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.0.3.tgz#06d1d77f9a1bea380f121897d78695902959fbc0"
+  integrity sha512-Q0xaG3YRG8QiTC4R6fHjHQPaPpz9pJBEi0AeOE4mQh/FuWOijFjGXMMOfQEaU9i3z76cNR7FobZZUQnL6IyfdQ==
   dependencies:
-    "@jest/types" "^28.1.0"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-util@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.1.tgz#ff39e436a1aca397c0ab998db5a51ae2b7080d05"
-  integrity sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==
+jest-validate@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.0.3.tgz#f9521581d7344685428afa0a4d110e9c519aeeb6"
+  integrity sha512-OebiqqT6lK8cbMPtrSoS3aZP4juID762lZvpf1u+smZnwTEBCBInan0GAIIhv36MxGaJvmq5uJm7dl5gVt+Zrw==
   dependencies:
-    "@jest/types" "^28.1.1"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
-jest-validate@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-28.1.1.tgz#59b7b339b3c85b5144bd0c06ad3600f503a4acc8"
-  integrity sha512-Kpf6gcClqFCIZ4ti5++XemYJWUPCFUW+N2gknn+KgnDf549iLul3cBuKVe1YcWRlaF8tZV8eJCap0eECOEE3Ug==
-  dependencies:
-    "@jest/types" "^28.1.1"
+    "@jest/types" "^29.0.3"
     camelcase "^6.2.0"
     chalk "^4.0.0"
-    jest-get-type "^28.0.2"
+    jest-get-type "^29.0.0"
     leven "^3.1.0"
-    pretty-format "^28.1.1"
+    pretty-format "^29.0.3"
 
-jest-watcher@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-28.1.1.tgz#533597fb3bfefd52b5cd115cd916cffd237fb60c"
-  integrity sha512-RQIpeZ8EIJMxbQrXpJQYIIlubBnB9imEHsxxE41f54ZwcqWLysL/A0ZcdMirf+XsMn3xfphVQVV4EW0/p7i7Ug==
+jest-watcher@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.0.3.tgz#8e220d1cc4f8029875e82015d084cab20f33d57f"
+  integrity sha512-tQX9lU91A+9tyUQKUMp0Ns8xAcdhC9fo73eqA3LFxP2bSgiF49TNcc+vf3qgGYYK9qRjFpXW9+4RgF/mbxyOOw==
   dependencies:
-    "@jest/test-result" "^28.1.1"
-    "@jest/types" "^28.1.1"
+    "@jest/test-result" "^29.0.3"
+    "@jest/types" "^29.0.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     emittery "^0.10.2"
-    jest-util "^28.1.1"
+    jest-util "^29.0.3"
     string-length "^4.0.1"
 
 jest-worker@^26.2.1:
@@ -2582,24 +2604,29 @@ jest-worker@^26.2.1:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-28.1.1.tgz#3480c73247171dfd01eda77200f0063ab6a3bf28"
-  integrity sha512-Au7slXB08C6h+xbJPp7VIb6U0XX5Kc9uel/WFc6/rcTzGiaVCBRngBExSYuXSLFPULPSYU3cJ3ybS988lNFQhQ==
+jest-worker@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.0.3.tgz#c2ba0aa7e41eec9eb0be8e8a322ae6518df72647"
+  integrity sha512-Tl/YWUugQOjoTYwjKdfJWkSOfhufJHO5LhXTSZC3TRoQKO+fuXnZAdoXXBlpLXKGODBL3OvdUasfDD4PcMe6ng==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-28.1.2.tgz#451ff24081ce31ca00b07b60c61add13aa96f8eb"
-  integrity sha512-Tuf05DwLeCh2cfWCQbcz9UxldoDyiR1E9Igaei5khjonKncYdc6LDfynKCEWozK0oLE3GD+xKAo2u8x/0s6GOg==
+jest@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.0.3.tgz#5227a0596d30791b2649eea347e4aa97f734944d"
+  integrity sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==
   dependencies:
-    "@jest/core" "^28.1.2"
-    "@jest/types" "^28.1.1"
+    "@jest/core" "^29.0.3"
+    "@jest/types" "^29.0.3"
     import-local "^3.0.2"
-    jest-cli "^28.1.2"
+    jest-cli "^29.0.3"
+
+js-sdsl@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.4.tgz#78793c90f80e8430b7d8dc94515b6c77d98a26a6"
+  integrity sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2832,6 +2859,11 @@ nanoid@^3.1.30:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
   integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -2917,7 +2949,7 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -3012,7 +3044,7 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-postcss@^8.2.x, postcss@^8.3.11:
+postcss@^8.2.x:
   version "8.4.5"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95"
   integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
@@ -3021,18 +3053,26 @@ postcss@^8.2.x, postcss@^8.3.11:
     picocolors "^1.0.0"
     source-map-js "^1.0.1"
 
+postcss@^8.4.16, postcss@^8.4.6:
+  version "8.4.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
+  integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-pretty-format@^28.0.0, pretty-format@^28.1.1:
-  version "28.1.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.1.tgz#f731530394e0f7fcd95aba6b43c50e02d86b95cb"
-  integrity sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==
+pretty-format@^29.0.0, pretty-format@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.0.3.tgz#23d5f8cabc9cbf209a77d49409d093d61166a811"
+  integrity sha512-cHudsvQr1K5vNVLbvYF/nv3Qy/F/BcEKxGuIeMiVMRHxPOO1RxXooP8g/ZrwAp7Dx+KdMZoOc7NxLHhMrP2f9Q==
   dependencies:
-    "@jest/schemas" "^28.0.2"
-    ansi-regex "^5.0.1"
+    "@jest/schemas" "^29.0.0"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
@@ -3157,7 +3197,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3190,21 +3230,21 @@ rollup-plugin-ts@^3.0.2:
     ts-clone-node "^1.0.0"
     tslib "^2.4.0"
 
-rollup@^2.75.7:
-  version "2.75.7"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.7.tgz#221ff11887ae271e37dcc649ba32ce1590aaa0b9"
-  integrity sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==
+rollup@^2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.0.tgz#9177992c9f09eb58c5e56cbfa641607a12b57ce2"
+  integrity sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==
   optionalDependencies:
     fsevents "~2.3.2"
 
-rtlcss@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-3.5.0.tgz#c9eb91269827a102bac7ae3115dd5d049de636c3"
-  integrity sha512-wzgMaMFHQTnyi9YOwsx9LjOxYXJPzS8sYnFaKm6R5ysvTkwzHiB0vxnbHwchHQT65PTdBjDG21/kQBWI7q9O7A==
+rtlcss@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-4.0.0.tgz#ba73233b9c79fbf66eb867f2ae937713acbf2b40"
+  integrity sha512-j6oypPP+mgFwDXL1JkLCtm6U/DQntMUqlv5SOhpgHhdIE+PmBcjrtAHIpXfbIup47kD5Sgja9JDsDF1NNOsBwQ==
   dependencies:
-    find-up "^5.0.0"
+    escalade "^3.1.1"
     picocolors "^1.0.0"
-    postcss "^8.3.11"
+    postcss "^8.4.6"
     strip-json-comments "^3.1.1"
 
 run-parallel@^1.1.9:
@@ -3287,7 +3327,7 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-source-map-js@^1.0.1:
+source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -3455,11 +3495,6 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-throat@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
-  integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
-
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -3492,14 +3527,14 @@ ts-clone-node@^1.0.0:
   dependencies:
     compatfactory "^1.0.1"
 
-ts-jest@^28.0.5:
-  version "28.0.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.5.tgz#31776f768fba6dfc8c061d488840ed0c8eeac8b9"
-  integrity sha512-Sx9FyP9pCY7pUzQpy4FgRZf2bhHY3za576HMKJFs+OnQ9jS96Du5vNsDKkyedQkik+sEabbKAnCliv9BEsHZgQ==
+ts-jest@^29.0.1:
+  version "29.0.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.1.tgz#3296b39d069dc55825ce1d059a9510b33c718b86"
+  integrity sha512-htQOHshgvhn93QLxrmxpiQPk69+M1g7govO1g6kf6GsjCv4uvRV0znVmDrrvjUrVCnTYeY4FBxTYYYD4airyJA==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
-    jest-util "^28.0.0"
+    jest-util "^29.0.0"
     json5 "^2.2.1"
     lodash.memoize "4.x"
     make-error "1.x"
@@ -3557,10 +3592,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 ua-parser-js@^1.0.2:
   version "1.0.2"
@@ -3586,11 +3621,6 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
This `RTLCSS` version brings these changes:
    * Support flipping `justify-content`, `justify-items` and `justify-self`
    * Support flipping length background position without using `calc`

### Input

```css
.test {
    background-position: 10px 20px;
    justify-content: left;
    justify-items: right; 
    justify-self: left;
}
```

### Output 

```css
.test {
    background-position: right 10px top 20px;
    justify-content: right;
    justify-items: left;
    justify-self: right;
}
```