### PR TITLE
Fix a bug related to overridden declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.1] - 2023-02-11
+
+- Fixed a bug related to overriden properties
+
 ## [4.0.0] - 2022-09-15
 
 - Upgrade RTLCSS to major version 4.0.0. This version brings these changes:

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -108,4 +108,18 @@ export interface ControlDirective {
     option?: string;
 }
 
-export type DeclarationHashMapProp = Record<string, Record<string, { decl: Declaration; value: string; }>>;
+export type DeclarationHashMapDetails = {
+    decl: Declaration;
+    value: string;
+    ignore: boolean;
+};
+
+export type DeclarationHashMapProp = {
+    ignore: boolean;
+    indexes: Record<string,DeclarationHashMapDetails>;
+};
+
+export type DeclarationHashMap = Record<
+    string,
+    DeclarationHashMapProp
+>;

--- a/tests/__snapshots__/overriding.test.ts.snap
+++ b/tests/__snapshots__/overriding.test.ts.snap
@@ -38,6 +38,80 @@ exports[`[[Mode: combined]] Overriding Tests:  Basic 1`] = `
 [dir="rtl"] .test4 {
     right: 10px;
     left: 0;
+}
+
+/* Overriden with non-flippable declarations should move only the last one */
+.test5 {
+    padding: 0 2px 0 4px;
+    padding: 0 4px 0 8px;
+}
+
+[dir="ltr"] .test5 {
+    padding: 0 8px 0 16px;
+}
+
+[dir="rtl"] .test5 {
+    padding: 0 16px 0 8px;
+}
+
+/* Overriden with flippable declarations should move all of them */
+[dir="ltr"] .test6 {
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test6 {
+    margin-left: 1px;
+    margin-left: 2px;
+    margin-left: 3px;
+}
+
+/* Overriden with flippable declarations but a counterpart flipped declaration should move only the last one */
+.test7 {
+    margin-right: 1px;
+    margin-right: 2px;
+}
+
+[dir="ltr"] .test7 {
+    margin-left: 4px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test7 {
+    margin-right: 4px;
+    margin-left: 3px;
+}
+
+.test8 {
+    margin-right: 1px;
+    margin-right: 2px;
+}
+
+[dir="ltr"] .test8 {
+    margin-left: 4px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test8 {
+    margin-right: 4px;
+    margin-left: 3px;
+}
+
+/* Overriden with flippable declarations but a counterpart flipped declaration should move only the last one even if there is a mirror */
+.test9 {
+    margin-right: 1px;
+    margin-right: 2px;
+}
+
+[dir="ltr"] .test9 {
+    margin-left: 1px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test9 {
+    margin-right: 1px;
+    margin-left: 3px;
 }"
 `;
 
@@ -45,6 +119,32 @@ exports[`[[Mode: diff]] Overriding Tests:  Basic 1`] = `
 ".test4 {
     right: 10px;
     left: 0;
+}
+
+.test5 {
+    padding: 0 16px 0 8px;
+}
+
+.test6 {
+    margin-right: 0;
+    margin-left: 1px;
+    margin-left: 2px;
+    margin-left: 3px;
+}
+
+.test7 {
+    margin-right: 4px;
+    margin-left: 3px;
+}
+
+.test8 {
+    margin-right: 4px;
+    margin-left: 3px;
+}
+
+.test9 {
+    margin-right: 1px;
+    margin-left: 3px;
 }"
 `;
 
@@ -83,5 +183,68 @@ exports[`[[Mode: override]] Overriding Tests:  Basic 1`] = `
 [dir="rtl"] .test4 {
     right: 10px;
     left: 0;
+}
+
+/* Overriden with non-flippable declarations should move only the last one */
+.test5 {
+    padding: 0 2px 0 4px;
+    padding: 0 4px 0 8px;
+    padding: 0 8px 0 16px;
+}
+
+[dir="rtl"] .test5 {
+    padding: 0 16px 0 8px;
+}
+
+/* Overriden with flippable declarations should move all of them */
+.test6 {
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test6 {
+    margin-right: 0;
+    margin-left: 1px;
+    margin-left: 2px;
+    margin-left: 3px;
+}
+
+/* Overriden with flippable declarations but a counterpart flipped declaration should move only the last one */
+.test7 {
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-left: 4px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test7 {
+    margin-right: 4px;
+    margin-left: 3px;
+}
+
+.test8 {
+    margin-left: 4px;
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test8 {
+    margin-right: 4px;
+    margin-left: 3px;
+}
+
+/* Overriden with flippable declarations but a counterpart flipped declaration should move only the last one even if there is a mirror */
+.test9 {
+    margin-left: 1px;
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-right: 3px;
+}
+
+[dir="rtl"] .test9 {
+    margin-right: 1px;
+    margin-left: 3px;
 }"
 `;

--- a/tests/css/overriding.css
+++ b/tests/css/overriding.css
@@ -28,3 +28,40 @@
     right: 10px;
     right: 0;
 }
+
+/* Overriden with non-flippable declarations should move only the last one */
+.test5 {
+    padding: 0 2px 0 4px;
+    padding: 0 4px 0 8px;
+    padding: 0 8px 0 16px;
+}
+
+/* Overriden with flippable declarations should move all of them */
+.test6 {
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-right: 3px;
+}
+
+/* Overriden with flippable declarations but a counterpart flipped declaration should move only the last one */
+.test7 {
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-left: 4px;
+    margin-right: 3px;
+}
+
+.test8 {
+    margin-left: 4px;
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-right: 3px;
+}
+
+/* Overriden with flippable declarations but a counterpart flipped declaration should move only the last one even if there is a mirror */
+.test9 {
+    margin-left: 1px;
+    margin-right: 1px;
+    margin-right: 2px;
+    margin-right: 3px;
+}


### PR DESCRIPTION
This pull request solves a bug related to overridden declarations. Previously, if a rule contained overridden declarations, only the last one was taken into account:

<table>
    <thead>
        <tr>
            <th>Input</th>
            <th>Output</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
<pre>
<code>.test {
    padding: 0 2px 0 4px;
    padding: 0 4px 0 8px;
    padding: 0 8px 0 16px;
}</code>
</pre>
            </td>
            <td>
<pre>
<code>.test {
    padding: 0 2px 0 4px;
    padding: 0 4px 0 8px;
}
[dir="ltr"] .test {
    padding: 0 8px 0 16px;
}
[dir="rtl"] .test {
    padding: 0 16px 0 8px;
}</code>
</pre>
            </td>
        </tr>
    </tbody>
</table>

But this is problematic with declarations that flip their property instead of their value:

<table>
    <thead>
        <tr>
            <th>Input</th>
            <th>Output</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
<pre>
<code>.test {
    margin-left: 1px;
    margin-left: 2px;
}</code>
</pre>
            </td>
            <td>
<pre>
<code>.test {
    margin-left: 1px;
}
[dir="ltr"] .test {
    margin-left: 2px;
}
[dir="rtl"] .test {
    margin-right: 2px;
}</code>
</pre>
            </td>
        </tr>
    </tbody>
</table>

>Notice that in RTL version the element will have `margin-left` and `margin-right` at the same time.

This pull request solves this issue. Some inputs and outputs after the fix:


<table>
    <thead>
        <tr>
            <th>Input</th>
            <th>Output</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
<pre>
<code>.test {
    padding: 0 2px 0 4px;
    padding: 0 4px 0 8px;
    padding: 0 8px 0 16px;
}</code>
</pre>
            </td>
            <td>
<pre>
<code>.test {
    padding: 0 2px 0 4px;
    padding: 0 4px 0 8px;
}
[dir="ltr"] .test {
    padding: 0 8px 0 16px;
}
[dir="rtl"] .test {
    padding: 0 16px 0 8px;
}</code>
</pre>
            </td>
        </tr>
        <tr>
            <td>
<pre>
<code>.test {
    margin-right: 1px;
    margin-right: 2px;
    margin-right: 3px;
}</code>
</pre>
            </td>
            <td>
<pre>
<code>[dir="ltr"] .test {
    margin-right: 1px;
    margin-right: 2px;
    margin-right: 3px;
}
[dir="rtl"] .test {
    margin-left: 1px;
    margin-left: 2px;
    margin-left: 3px;
}</code>
</pre>
            </td>
        </tr>
        <tr>
            <td>
<pre>
<code>.test {
    margin-right: 1px;
    margin-right: 2px;
    margin-left: 4px;
    margin-right: 3px;
}</code>
</pre>
            </td>
            <td>
<pre>
<code>.test {
    margin-right: 1px;
    margin-right: 2px;
}
[dir="ltr"] .test {
    margin-left: 4px;
    margin-right: 3px;
}
[dir="rtl"] .test {
    margin-right: 4px;
    margin-left: 3px;
}</code>
</pre>
            </td>
        </tr>
        <tr>
            <td>
<pre>
<code>.test {
    margin-left: 4px;
    margin-right: 1px;
    margin-right: 2px;
    margin-right: 3px;
}</code>
</pre>
            </td>
            <td>
<pre>
<code>.test {
    margin-right: 1px;
    margin-right: 2px;
}
[dir="ltr"] .test {
    margin-left: 4px;
    margin-right: 3px;
}
[dir="rtl"] .test {
    margin-right: 4px;
    margin-left: 3px;
}</code>
</pre>
            </td>
        </tr>
    </tbody>
</table>
