### PR TITLE
Create Github releases after a successful NPM deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,3 +25,20 @@ jobs:
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Extract the release body from CHANGELOG.md
+        id: changelog
+        shell: bash
+        run: |
+          node ./scripts/extract_last_release_body.js
+          RELEASE=$(cat ./RELEASE.md)
+          echo "RELEASE_BODY=$RELEASE" >> $GITHUB_OUTPUT
+      - name: Upload release asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./index.js
+          asset_name: postcss-rtlcss.js
+          tag: ${{ github.ref }}
+          body: |
+            ${{ steps.changelog.outputs.RELEASE_BODY }}
+          overwrite: true

--- a/scripts/extract_last_release_body.js
+++ b/scripts/extract_last_release_body.js
@@ -1,0 +1,9 @@
+const fs = require('fs/promises');
+
+const createRelease = async() => {
+    const data = await fs.readFile('./CHANGELOG.md', { encoding: 'utf8' });
+    const RELEASE = data.replace(/^#[^#]*?##\s.*?(\d{4}-\d{2}-\d{2}[^#]*)\n[\s\S]*$/, '$1');
+    await fs.writeFile('./RELEASE.md', RELEASE);
+};
+
+createRelease();


### PR DESCRIPTION
This pull request implements a Github job in the deploy action to create a Github release after a successful NPM deployment.

Closes #192