### PR TITLE
Avoid removing empty rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.4] - 2023-04-08
+
+- Fixed unwanted removal of empty rules
+
 ## [4.0.3] - 2023-03-04
 
 - Fixed a bug releated to overriden properties

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ function postcssRTLCSS (options: PluginOptions = {}): Plugin {
             clean(css);
         }
     });
-};
+}
 
 postcssRTLCSS.postcss = true;
 

--- a/src/utilities/clean.ts
+++ b/src/utilities/clean.ts
@@ -58,7 +58,9 @@ export const clean = (css: Container): void => {
             !!(node as Container).nodes
         ) {
             if (!ruleHasChildren(node as Container)) {
-                node.remove();
+                if (mode === Mode.diff) {
+                    node.remove();
+                }
             } else {
                 const prev = node.prev();
                 if (prev) {

--- a/tests/__snapshots__/empty-rules.test.ts.snap
+++ b/tests/__snapshots__/empty-rules.test.ts.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: combined]] Empty Rules Tests:  Basic 1`] = `
+".test1 {}
+
+.test2, .test3 {}
+
+[dir="ltr"] .test4 {
+    text-align: left;
+}
+
+[dir="rtl"] .test4 {
+    text-align: right;
+}
+
+.test5 {
+    color: red;
+}
+
+[dir="ltr"] .test5 {
+    padding-left: 20px;
+}
+
+[dir="rtl"] .test5 {
+    padding-right: 20px;
+}"
+`;
+
+exports[`[[Mode: diff]] Empty Rules Tests:  Basic 1`] = `
+".test4 {
+    text-align: right;
+}
+
+.test5 {
+    padding-left: 0;
+    padding-right: 20px;
+}"
+`;
+
+exports[`[[Mode: override]] Empty Rules Tests:  Basic 1`] = `
+".test1 {}
+
+.test2, .test3 {}
+
+.test4 {
+    text-align: left;
+}
+
+[dir="rtl"] .test4 {
+    text-align: right;
+}
+
+.test5 {
+    color: red;
+    padding-left: 20px;
+}
+
+[dir="rtl"] .test5 {
+    padding-left: 0;
+    padding-right: 20px;
+}"
+`;

--- a/tests/css/empty-rules.css
+++ b/tests/css/empty-rules.css
@@ -1,0 +1,12 @@
+.test1 {}
+
+.test2, .test3 {}
+
+.test4 {
+    text-align: left;
+}
+
+.test5 {
+    color: red;
+    padding-left: 20px;
+}

--- a/tests/empty-rules.test.ts
+++ b/tests/empty-rules.test.ts
@@ -1,0 +1,21 @@
+import postcss from 'postcss';
+import postcssRTLCSS from '../src';
+import { PluginOptions } from '../src/@types';
+import { readCSSFile, runTests } from './utils';
+
+runTests({}, (pluginOptions: PluginOptions): void => {
+    describe(`[[Mode: ${pluginOptions.mode}]] Empty Rules Tests: `, () => {
+        let input = '';
+  
+        beforeEach(async (): Promise<void> => {
+            input = input || await readCSSFile('empty-rules.css');
+        });
+
+        it('Basic', (): void => {
+            const options: PluginOptions = { ...pluginOptions };
+            const output = postcss([postcssRTLCSS(options)]).process(input);
+            expect(output.css).toMatchSnapshot();
+            expect(output.warnings()).toHaveLength(0);
+          });
+    });
+});


### PR DESCRIPTION
This pull request fixes the unwanted deletion of empty rules. The plugin should clean the rules that are empty due to its internal process, but should not clean the rules that were there empty in the original CSS file, if a user wants to clean those rules, they should use another `postcss` plugin for that purpose. Cleaning empty CSS rules is out of the scope of this plugin.

Closes #190 