### PR TITLE
Upload only esm bundles

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -76,11 +76,9 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            index.js
-            index.d.ts
-            options.js
-            options.d.ts
             esm/index.js
+            index.d.ts
             esm/options.js
+            options.d.ts
           body: |
             ${{ steps.build_changelog.outputs.changelog }}


### PR DESCRIPTION
In a release, assets should have unique names. CommonJS and ESM assets have the same name and this was creating an issue with the assets uploader action. This pull request adds only the ESM bundles to the assets.