### PR TITLE
Fix an error related to empty atRules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.5] - 2023-04-21
+
+- Fixed an error related to empty atRules
+
 ## [4.0.4] - 2023-04-08
 
 - Fixed unwanted removal of empty rules

--- a/src/utilities/rules.ts
+++ b/src/utilities/rules.ts
@@ -28,6 +28,7 @@ export const ruleHasDeclarations = (rule: Rule): boolean => {
 };
 
 export const ruleHasChildren = (rule: Container): boolean => {
+    if (!rule.nodes) return false;
     return rule.some(
         (node: Node) => (
             node.type === DECLARATION_TYPE ||

--- a/tests/__snapshots__/nested-rules.test.ts.snap
+++ b/tests/__snapshots__/nested-rules.test.ts.snap
@@ -181,6 +181,14 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
     .test13 {
         text-align: left;
     }
+}
+
+@mixin padding {
+    padding-left: 10px;
+}
+
+.test14 {
+   @include padding;
 }"
 `;
 
@@ -365,6 +373,14 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
     .test13 {
         text-align: left;
     }
+}
+
+@mixin padding {
+    padding-left: 10px;
+}
+
+.test14 {
+   @include padding;
 }"
 `;
 
@@ -441,6 +457,10 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: ltr} 1`] = `
     .test13 {
         text-align: left;
     }
+}
+
+@mixin padding {
+    padding-left: 10px;
 }"
 `;
 
@@ -517,6 +537,10 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: rtl} 1`] = `
     .test13 {
         text-align: left;
     }
+}
+
+@mixin padding {
+    padding-left: 10px;
 }"
 `;
 
@@ -674,6 +698,14 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
     .test13 {
         text-align: left;
     }
+}
+
+@mixin padding {
+    padding-left: 10px;
+}
+
+.test14 {
+   @include padding;
 }"
 `;
 
@@ -831,5 +863,13 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
     .test13 {
         text-align: left;
     }
+}
+
+@mixin padding {
+    padding-left: 10px;
+}
+
+.test14 {
+   @include padding;
 }"
 `;

--- a/tests/css/input-nested.scss
+++ b/tests/css/input-nested.scss
@@ -76,3 +76,11 @@
         text-align: right;
     }
 }
+
+@mixin padding {
+    padding-left: 10px;
+}
+
+.test14 {
+   @include padding;
+}


### PR DESCRIPTION
AtRules used by some plugins/libraries to create mixins, do not have children. E.g:

```scss
@include some-mixin;
```

This was provoking an error with CSS code with these kind of rules:

>Cannot read properties of undefined (reading 'some')

This pull request fixes this issue

Closes #204 
