### PR TITLE
Fix ESM types

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,8 +78,8 @@ jobs:
         with:
           files: |
             esm/index.js
-            index.d.ts
+            esm/index.d.ts
             esm/options.js
-            options.d.ts
+            esm/options.d.ts
           body: |
             ${{ steps.build_changelog.outputs.changelog }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.7] - 2023-08-12
+
+- Fix ESM types
+
 ## [4.0.6] - 2023-05-03
 
 - Update RTLCSS to version 4.1.0

--- a/package.json
+++ b/package.json
@@ -18,12 +18,24 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "require": "./index.js",
-      "import": "./esm/index.js"
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      }
     },
     "./options": {
-      "require": "./options.js",
-      "import": "./esm/options.js"
+      "require": {
+        "types": "./options.d.ts",
+        "default": "./options.js"
+      },
+      "import": {
+        "types": "./esm/options.d.ts",
+        "default": "./esm/options.js"
+      }
     }
   },
   "files": [

--- a/scripts/copy.sh
+++ b/scripts/copy.sh
@@ -2,17 +2,7 @@
 
 mkdir esm
 
-## index
-cp dist/index.js index.js
-cp dist/esm/index.js esm/index.js
-
-## options
-cp dist/options.js options.js
-cp dist/esm/options.js esm/options.js
-
-## type definitions
-cp dist/index.d.ts index.d.ts
-cp dist/options.d.ts options.d.ts
+cp -a dist/. ./
 
 ## esm package
 echo '{\n    "type": "module"\n}' > esm/package.json


### PR DESCRIPTION
Following the recommendations in the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing). This is to avoid `TypeScript` complaining about missing types when the ESM module is used:

>Could not find a declaration file for module 'postcss-rtlcss'. '/path-to-project/node_modules/postcss-rtlcss/esm/index.js' implicitly has an 'any' type.
  There are types at '/path-to-project/node_modules/postcss-rtlcss/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'postcss-rtlcss' library may need to update its package.json or typings.ts(7016)