### PR TITLE
Add margin-block and padding-block properties to logical declarations override

### DIFF
--- a/src/data/logical-declarations.json
+++ b/src/data/logical-declarations.json
@@ -125,7 +125,10 @@
         "overrides": [
             "margin-inline",
             "margin-inline-end",
-            "margin-inline-start"
+            "margin-inline-start",
+            "margin-block",
+            "margin-block-end",
+            "margin-block-start"
         ]
     },
     "margin-left": {
@@ -149,7 +152,10 @@
         "overrides": [
             "padding-inline",
             "padding-inline-end",
-            "padding-inline-start"
+            "padding-inline-start",
+            "padding-block",
+            "padding-block-end",
+            "padding-block-start"
         ]
     },
     "padding-left": {

--- a/tests/__snapshots__/autorename.test.ts.snap
+++ b/tests/__snapshots__/autorename.test.ts.snap
@@ -612,6 +612,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1227,6 +1237,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1842,6 +1862,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -2457,6 +2487,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3072,6 +3112,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3687,6 +3737,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -4302,6 +4362,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -6288,6 +6358,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -6855,6 +6935,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -7422,6 +7512,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -7989,6 +8089,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -8556,6 +8666,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -9123,6 +9243,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -9690,5 +9820,15 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;

--- a/tests/__snapshots__/basic-options.test.ts.snap
+++ b/tests/__snapshots__/basic-options.test.ts.snap
@@ -680,6 +680,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1299,6 +1309,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1982,6 +2002,16 @@ html[dir="ltr"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -2597,6 +2627,16 @@ html[dir="ltr"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3213,6 +3253,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3828,6 +3878,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -5724,6 +5784,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -6295,6 +6365,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -6918,6 +6998,16 @@ html[dir="ltr"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -7479,6 +7569,16 @@ html[dir="ltr"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -8047,6 +8147,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -8614,5 +8724,15 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;

--- a/tests/__snapshots__/prefixes.test.ts.snap
+++ b/tests/__snapshots__/prefixes.test.ts.snap
@@ -612,6 +612,16 @@ html.rtl .test50 {
 
 .ltr .test51, .rtl .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1237,6 +1247,16 @@ html.rtl .test50, html.right-to-left .test50 {
 
 .ltr .test51, .left-to-right .test51, .rtl .test51, .right-to-left .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1866,6 +1886,16 @@ html.rtl .test50, html.right-to-left .test50 {
 
 .ltr .test51, .left-to-right .test51, .rtl .test51, .right-to-left .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -2481,6 +2511,16 @@ html.rtl .test50 {
 
 .ltr.test51, .rtl.test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3096,6 +3136,16 @@ html[dir="rtl"] .test50 {
 
 [dir] > .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -4615,6 +4665,16 @@ html.rtl .test50 {
 
 .ltr .test51, .rtl .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -5187,6 +5247,16 @@ html.rtl .test50, html.right-to-left .test50 {
 
 .ltr .test51, .left-to-right .test51, .rtl .test51, .right-to-left .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -5763,6 +5833,16 @@ html.rtl .test50, html.right-to-left .test50 {
 
 .ltr .test51, .left-to-right .test51, .rtl .test51, .right-to-left .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -6330,6 +6410,16 @@ html.rtl .test50 {
 
 .ltr.test51, .rtl.test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -6897,5 +6987,15 @@ html[dir="rtl"] .test50 {
 
 [dir] > .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix.test.ts.snap
+++ b/tests/__snapshots__/safe-prefix.test.ts.snap
@@ -638,6 +638,19 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1344,6 +1357,19 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1986,6 +2012,19 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -2627,6 +2666,19 @@ html[dir="ltr"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -2891,6 +2943,15 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test52 {
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3199,6 +3260,15 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test52 {
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3463,6 +3533,15 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test52 {
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3727,6 +3806,15 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test52 {
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -4357,6 +4445,19 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -5049,6 +5150,19 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -5683,6 +5797,19 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -6307,5 +6434,18 @@ html[dir="ltr"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+}
+
+[dir] .test52 {
+    padding-block: 1px 2px;
+}
+
+[dir] .test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;

--- a/tests/__snapshots__/string-map.test.ts.snap
+++ b/tests/__snapshots__/string-map.test.ts.snap
@@ -616,6 +616,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1235,6 +1245,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -1854,6 +1874,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -2473,6 +2503,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -3820,6 +3860,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -4391,6 +4441,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -4962,6 +5022,16 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;
 
@@ -5533,5 +5603,15 @@ html[dir="rtl"] .test50 {
 
 [dir] .test51 {
     border: none;
+}
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
 }"
 `;

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -429,3 +429,13 @@ html .test50 {
     border-left: 1px solid #FFF;
     border: none;
 }
+
+.test52 {
+    color: red;
+    padding-block: 1px 2px;
+}
+
+.test53 {
+    margin-block-start: 10px;
+    margin-block-end: 5px;
+}


### PR DESCRIPTION
This pull request adds `margin-block`, `margin-block-start`, `margin-block-end`, `padding-block`, `padding-block-start` and `padding-block-end` to the logical declarations that can be overridden by `margin` and `padding` respectively. This adds these declarations to the ones affected by `safeBothPrefix` option.

Closes #222.