### PR TITLE
Refactor enum values types

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -21,9 +21,9 @@ export enum Autorename {
     strict = 'strict'
 }
 
-export type ModeValues = keyof typeof Mode;
-export type SourceValues = keyof typeof Source;
-export type AutorenameValues = keyof typeof Autorename;
+export type ModeValues = `${Mode}`;
+export type SourceValues = `${Source}`;
+export type AutorenameValues = `${Autorename}`;
 
 export type strings = string | string[];
 


### PR DESCRIPTION
The enum values types were using the enums' keys just because the keys and the values were the same, but it is better to get the string representation of the enums that returns the exact values.

### Enum

```typescript
enum Mode {
    combined = 'combined',
    override = 'override',
    diff = 'diff'
}
```

### Enum values

```typescript
// Before
type ModeValues = keyof typeof Mode; // 'combined' | 'override' | 'diff'

// After
type ModeValues = `${Mode}`; // 'combined' | 'override' | 'diff'
```