### PR TITLE
Publish the package using npm provenance

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: node:18
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +25,7 @@ jobs:
       - name: Publish
         run: |
           yarn install --frozen-lockfile --ignore-scripts --prefer-offline
-          npm publish
+          npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build Changelog


### PR DESCRIPTION
This pull request adds [the --provenance flag](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions) to the `npm publish` command in the deploy workflow.