### PR TITLE
Restore Set up node registry url

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
       - name: Publish
         run: |
           pnpm install --ignore-scripts --prefer-offline


### PR DESCRIPTION
During the migration to pnpm the registry-url parameter of the Node set up step was removed. This pull request restores it.