### PR TITLE
Make aliases affect both-prefixed and safe-prefixed declarations

### DIFF
--- a/src/parsers/declarations.ts
+++ b/src/parsers/declarations.ts
@@ -178,18 +178,33 @@ export const parseDeclarations = (
             const declPropUnprefixed = vendor.unprefixed(declProp);
             const declValue = decl.value.trim();
             const declIndexes = Object.keys(declarationHashMap[declProp].indexes).map(Number);
-            const isAnimation = declPropUnprefixed === ANIMATION_PROP || declPropUnprefixed === ANIMATION_NAME_PROP;
+            const isAnimation = (
+                declPropUnprefixed === ANIMATION_PROP ||
+                declPropUnprefixed === ANIMATION_NAME_PROP ||
+                aliases[declPropUnprefixed] === ANIMATION_PROP ||
+                aliases[declPropUnprefixed] === ANIMATION_NAME_PROP
+            );
             const declFlippedProp = declFlipped.prop.trim();
             const declFlippedValue = declFlipped.value.trim();
-            const overridenBy = declarations[declPropUnprefixed];
-            const hasBeenOverriden = declarationsProps.includes(declPropUnprefixed) || (
-                overridenBy
-                    ? overridenBy.some((d: string): boolean => declarationsProps.indexOf(d) >= 0)
-                    : false
+            const overridenBy = aliases[declPropUnprefixed]
+                ? declarations[aliases[declPropUnprefixed]]
+                : declarations[declPropUnprefixed];
+            const hasBeenOverriden = (
+                declarationsProps.includes(declPropUnprefixed) ||
+                declarationsProps.includes(aliases[declPropUnprefixed]) ||
+                (
+                    overridenBy
+                        ? overridenBy.some((d: string): boolean => declarationsProps.indexOf(d) >= 0)
+                        : false
+                )
             );
-            const overridesPrevious = checkOverrides(declPropUnprefixed, declarationsProps);
+            const overridesPrevious = aliases[declPropUnprefixed]
+                ? checkOverrides(aliases[declPropUnprefixed], declarationsProps)
+                : checkOverrides(declPropUnprefixed, declarationsProps);
             const isConflictedDeclaration = safeBothPrefix
-                ? !!allDeclarations[declPropUnprefixed]
+                ? aliases[declPropUnprefixed]
+                    ? !!(allDeclarations[aliases[declPropUnprefixed]])
+                    : !!(allDeclarations[declPropUnprefixed])
                 : false;
             const sourceDirectiveValue = getSourceDirectiveValue(
                 controlDirectives,

--- a/tests/__snapshots__/aliases-custom-declarations/combined/no-aliases-safe-both-prefix-false.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/combined/no-aliases-safe-both-prefix-false.snapshot
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: combined]] Aliases Tests: without aliases and safeBothPrefix false 1`] = `
+".test1 {
+    view-timeline: --row-a block;
+    animation-range: cover 0% cover 100%;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="ltr"] .test1 {
+    transform: translate3d(-21vh, 0, 0);
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    color: white;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    custom-clip-background: text;
+    color: rgba(255, 242, 126, 1);
+    custom-padding: 20px;
+}
+
+[dir="ltr"] .test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/combined/no-aliases-safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/combined/no-aliases-safe-both-prefix-true.snapshot
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: combined]] Aliases Tests: without aliases and safeBothPrefix true 1`] = `
+".test1 {
+    view-timeline: --row-a block;
+    animation-range: cover 0% cover 100%;
+}
+
+[dir] .test1 {
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="ltr"] .test1 {
+    transform: translate3d(-21vh, 0, 0);
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    color: white;
+    custom-border-width: 2px;
+}
+
+[dir] .test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+}
+
+.test3 {
+    custom-clip-background: text;
+    color: rgba(255, 242, 126, 1);
+    custom-padding: 20px;
+}
+
+[dir="ltr"] .test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/combined/with-aliases-safe-both-prefix-false.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/combined/with-aliases-safe-both-prefix-false.snapshot
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: combined]] Aliases Tests: with aliases and safeBothPrefix false 1`] = `
+".test1 {
+    view-timeline: --row-a block;
+    animation-range: cover 0% cover 100%;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="ltr"] .test1 {
+    transform: translate3d(-21vh, 0, 0);
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    color: white;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    color: rgba(255, 242, 126, 1);
+    custom-padding: 20px;
+}
+
+[dir="ltr"] .test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    custom-clip-background: text;
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/combined/with-aliases-safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/combined/with-aliases-safe-both-prefix-true.snapshot
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: combined]] Aliases Tests: with aliases and safeBothPrefix true 1`] = `
+".test1 {
+    animation-range: cover 0% cover 100%;
+}
+
+[dir] .test1 {
+    view-timeline: --row-a block;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="ltr"] .test1 {
+    transform: translate3d(-21vh, 0, 0);
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    color: white;
+}
+
+[dir] .test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    color: rgba(255, 242, 126, 1);
+}
+
+[dir] .test3 {
+    custom-padding: 20px;
+}
+
+[dir="ltr"] .test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    custom-clip-background: text;
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/diff/no-aliases-safe-both-prefix-false.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/diff/no-aliases-safe-both-prefix-false.snapshot
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: diff]] Aliases Tests: without aliases and safeBothPrefix false 1`] = `
+".test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/diff/no-aliases-safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/diff/no-aliases-safe-both-prefix-true.snapshot
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: diff]] Aliases Tests: without aliases and safeBothPrefix true 1`] = `
+".test1 {
+    transform: translate3d(21vh, 0, 0);
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+.test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+}
+
+.test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/diff/with-aliases-safe-both-prefix-false.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/diff/with-aliases-safe-both-prefix-false.snapshot
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: diff]] Aliases Tests: with aliases and safeBothPrefix false 1`] = `
+".test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+    custom-clip-background: text;
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/diff/with-aliases-safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/diff/with-aliases-safe-both-prefix-true.snapshot
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: diff]] Aliases Tests: with aliases and safeBothPrefix true 1`] = `
+".test1 {
+    transform: translate3d(21vh, 0, 0);
+    view-timeline: --row-a block;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+.test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+    custom-clip-background: text;
+    background-position: top;
+    custom-padding: 20px;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/override/no-aliases-safe-both-prefix-false.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/override/no-aliases-safe-both-prefix-false.snapshot
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: override]] Aliases Tests: without aliases and safeBothPrefix false 1`] = `
+".test1 {
+    transform: translate3d(-21vh, 0, 0);
+    view-timeline: --row-a block;
+    animation-range: cover 0% cover 100%;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    color: white;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    custom-clip-background: text;
+    color: rgba(255, 242, 126, 1);
+    custom-padding: 20px;
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/override/no-aliases-safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/override/no-aliases-safe-both-prefix-true.snapshot
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: override]] Aliases Tests: without aliases and safeBothPrefix true 1`] = `
+".test1 {
+    view-timeline: --row-a block;
+    animation-range: cover 0% cover 100%;
+}
+
+[dir] .test1 {
+    transform: translate3d(-21vh, 0, 0);
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    color: white;
+    custom-border-width: 2px;
+}
+
+[dir] .test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+}
+
+.test3 {
+    custom-clip-background: text;
+    color: rgba(255, 242, 126, 1);
+    custom-padding: 20px;
+}
+
+[dir] .test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/override/with-aliases-safe-both-prefix-false.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/override/with-aliases-safe-both-prefix-false.snapshot
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: override]] Aliases Tests: with aliases and safeBothPrefix false 1`] = `
+".test1 {
+    transform: translate3d(-21vh, 0, 0);
+    view-timeline: --row-a block;
+    animation-range: cover 0% cover 100%;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    color: white;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    color: rgba(255, 242, 126, 1);
+    custom-padding: 20px;
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    custom-clip-background: text;
+    background-position: top;
+}"
+`;

--- a/tests/__snapshots__/aliases-custom-declarations/override/with-aliases-safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/aliases-custom-declarations/override/with-aliases-safe-both-prefix-true.snapshot
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[[Mode: override]] Aliases Tests: with aliases and safeBothPrefix true 1`] = `
+".test1 {
+    animation-range: cover 0% cover 100%;
+}
+
+[dir] .test1 {
+    transform: translate3d(-21vh, 0, 0);
+    view-timeline: --row-a block;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+[dir="rtl"] .test1 {
+    transform: translate3d(21vh, 0, 0);
+}
+
+.test2 {
+    color: white;
+}
+
+[dir] .test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    color: rgba(255, 242, 126, 1);
+}
+
+[dir] .test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    custom-padding: 20px;
+}
+
+[dir="rtl"] .test3 {
+    background: linear-gradient(-180deg, #fff27e 0%, #ffffff 100%);
+}
+
+[dir] .test3 {
+    custom-clip-background: text;
+    background-position: top;
+}"
+`;

--- a/tests/aliases-custom-declarations.test.ts
+++ b/tests/aliases-custom-declarations.test.ts
@@ -1,0 +1,66 @@
+import postcss from 'postcss';
+import postcssRTLCSS from '../src';
+import { PluginOptions } from '../src/@types';
+import {
+  readCSSFile,
+  runTests,
+  createSnapshotFileName
+} from './utils';
+import { propsAliases } from './constants';
+import 'jest-specific-snapshot';
+
+const BASE_NAME = 'aliases-custom-declarations';
+
+const baseOptions: PluginOptions = {
+    aliases: propsAliases
+};
+
+runTests(baseOptions, (pluginOptions: PluginOptions): void => {
+
+  describe(`[[Mode: ${pluginOptions.mode}]] Aliases Tests:`, (): void => {
+
+    let input = '';
+  
+    beforeEach(async (): Promise<void> => {
+      input = input || await readCSSFile('input-aliases.css');
+    });
+  
+    it('without aliases and safeBothPrefix false', (): void => {
+      const options: PluginOptions = { ...pluginOptions, aliases: {} };
+      const output = postcss([postcssRTLCSS(options)]).process(input);
+      expect(output.css).toMatchSpecificSnapshot(
+        createSnapshotFileName(BASE_NAME,'no-aliases-safe-both-prefix-false', pluginOptions.mode)
+      );
+      expect(output.warnings()).toHaveLength(0);
+    });
+
+    it('without aliases and safeBothPrefix true', (): void => {
+        const options: PluginOptions = { ...pluginOptions, aliases: {}, safeBothPrefix: true };
+        const output = postcss([postcssRTLCSS(options)]).process(input);
+        expect(output.css).toMatchSpecificSnapshot(
+          createSnapshotFileName(BASE_NAME,'no-aliases-safe-both-prefix-true', pluginOptions.mode)
+        );
+        expect(output.warnings()).toHaveLength(0);
+      });
+
+    it('with aliases and safeBothPrefix false', (): void => {
+        const options: PluginOptions = { ...pluginOptions };
+        const output = postcss([postcssRTLCSS(options)]).process(input);
+        expect(output.css).toMatchSpecificSnapshot(
+          createSnapshotFileName(BASE_NAME,'with-aliases-safe-both-prefix-false', pluginOptions.mode)
+        );
+        expect(output.warnings()).toHaveLength(0);
+      });
+
+    it('with aliases and safeBothPrefix true', (): void => {
+        const options: PluginOptions = { ...pluginOptions, safeBothPrefix: true };
+        const output = postcss([postcssRTLCSS(options)]).process(input);
+        expect(output.css).toMatchSpecificSnapshot(
+          createSnapshotFileName(BASE_NAME,'with-aliases-safe-both-prefix-true', pluginOptions.mode)
+        );
+        expect(output.warnings()).toHaveLength(0);
+      });
+  
+  });
+
+});

--- a/tests/constants/index.ts
+++ b/tests/constants/index.ts
@@ -1,5 +1,8 @@
 const PADDING = 'padding';
 const MARGIN = 'margin';
+const ANIMATION = 'animation';
+const BORDER_WIDTH = 'border-width';
+const BACKGROUND_CLIP = 'background-clip';
 
 export const aliases = {
   '--small-padding': PADDING,
@@ -7,4 +10,11 @@ export const aliases = {
   '--custom-margin': MARGIN,
   '--small-margin': MARGIN,
   '--large-margin': MARGIN
+};
+
+export const propsAliases = {
+  'view-timeline': ANIMATION,
+  'custom-border-width': BORDER_WIDTH,
+  'custom-clip-background': BACKGROUND_CLIP,
+  'custom-padding': PADDING
 };

--- a/tests/css/input-aliases.css
+++ b/tests/css/input-aliases.css
@@ -1,0 +1,22 @@
+.test1 {
+    transform: translate3d(-21vh, 0, 0);
+    view-timeline: --row-a block;
+    animation-range: cover 0% cover 100%;
+    animation-timing-function: var(--timing-function);
+    animation-name: slide-in;
+}
+
+.test2 {
+    border: 1px solid;
+    border-color: #FF00FF;
+    color: white;
+    custom-border-width: 2px;
+}
+
+.test3 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    custom-clip-background: text;
+    background-position: top;
+    color: rgba(255, 242, 126, 1);
+    custom-padding: 20px;
+}


### PR DESCRIPTION
This pull request makes aliases being taken into account for both-prefixed and safe-prefixed declarations. In this way if a declaration needs to be moved to a prefixed rule with the `bothPrefix`, either because it can be overriden or because the `safeBothPrefix` rule is set, it will do the same with an alias of such a declaration.