### PR TITLE
Add support for prefixes in `::view-transition` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.1.3] - 2024-05-13
+
+- Add support for prefixes in `::view-transition` rules
+
 ## [5.1.2] - 2024-04-16
 
 - Remove preinstall script

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ This function will be used to transform the selectors and prefixing them at our 
 
 >Notes:
 >* If the function doesn‘t return a string, the default prefixing logic will be used.
->* If this function is used, be aware that rules using `html` or `:root` will follow the custom prefixing logic. You should cover these cases.
+>* If this function is used, be aware that rules using `html`, `:root` or `:::view-transition` will follow the custom prefixing logic. You should cover these cases.
 
 ##### input
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,6 +14,7 @@ export const RTL_CONTROL_DIRECTIVE_REG_EXP = /^\/\*!? *rtl:?(begin|end)?:(\w+):?
 export const FLIP_PROPERTY_REGEXP = /(right|left)/i;
 export const HTML_SELECTOR_REGEXP = /^(html)(?=\W|$)/;
 export const ROOT_SELECTOR_REGEXP = /(:root)(?=\W|$)/;
+export const VIEW_TRANSITION_REGEXP = /^(::view-transition(?:-(?:new|old|group|image-pair))?\()/;
 export const REG_EXP_CHARACTERS_REG_EXP = /[.?*+^$[\]\\(){}|-]/g;
 export const LAST_WORD_CHARACTER_REG_EXP = /\w$/;
 

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -3,6 +3,7 @@ import { strings, Mode, Source } from '@types';
 import {
     HTML_SELECTOR_REGEXP,
     ROOT_SELECTOR_REGEXP,
+    VIEW_TRANSITION_REGEXP,
     STRING_TYPE
 } from '@constants';
 import { store } from '@data/store';
@@ -19,6 +20,9 @@ const addPrefix = (prefix: string, selector: string): string => {
     }
     if (ROOT_SELECTOR_REGEXP.test(selector)) {
         return selector.replace(ROOT_SELECTOR_REGEXP, `${prefix}$1`);
+    }
+    if (VIEW_TRANSITION_REGEXP.test(selector)) {
+        return selector.replace(VIEW_TRANSITION_REGEXP, `${prefix}$1`);
     }
     return `${prefix} ${selector}`;
 };

--- a/tests/__snapshots__/basic-options/combined/basic.snapshot
+++ b/tests/__snapshots__/basic-options/combined/basic.snapshot
@@ -626,6 +626,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/combined/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/process-keyframes-true.snapshot
@@ -694,6 +694,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/combined/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/process-url-true.snapshot
@@ -638,6 +638,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/combined/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/source-rtl-and-process-keyframes-true.snapshot
@@ -694,6 +694,22 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/combined/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/combined/source-rtl.snapshot
@@ -626,6 +626,22 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/combined/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/use-calc-true.snapshot
@@ -627,6 +627,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/diff/basic.snapshot
+++ b/tests/__snapshots__/basic-options/diff/basic.snapshot
@@ -191,6 +191,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/basic-options/diff/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/process-keyframes-true.snapshot
@@ -253,6 +253,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/basic-options/diff/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/process-url-true.snapshot
@@ -201,6 +201,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/basic-options/diff/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/source-rtl-and-process-keyframes-true.snapshot
@@ -253,6 +253,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/basic-options/diff/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/diff/source-rtl.snapshot
@@ -191,6 +191,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/basic-options/diff/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/use-calc-true.snapshot
@@ -192,6 +192,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/basic-options/override/basic.snapshot
+++ b/tests/__snapshots__/basic-options/override/basic.snapshot
@@ -577,6 +577,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/override/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/process-keyframes-true.snapshot
@@ -639,6 +639,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/override/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/process-url-true.snapshot
@@ -589,6 +589,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/override/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/source-rtl-and-process-keyframes-true.snapshot
@@ -633,6 +633,19 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/override/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/override/source-rtl.snapshot
@@ -571,6 +571,19 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/basic-options/override/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/use-calc-true.snapshot
@@ -578,6 +578,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -636,6 +636,26 @@ html.rtl .test50, html.right-to-left .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+.ltr::view-transition-old(root),
+.left-to-right::view-transition-old(root),
+.ltr::view-transition-new(root),
+.left-to-right::view-transition-new(root) {
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.right-to-left::view-transition-old(root),
+.rtl::view-transition-new(root),
+.right-to-left::view-transition-new(root) {
+    left: 0;
+}
+
 .ltr .test51, .left-to-right .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix.snapshot
@@ -626,6 +626,22 @@ html.rtl .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+.ltr::view-transition-old(root),
+.ltr::view-transition-new(root) {
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.rtl::view-transition-new(root) {
+    left: 0;
+}
+
 .ltr .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -648,6 +648,26 @@ html.rtl .test50, html.right-to-left .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+.ltr::view-transition-old(root),
+.left-to-right::view-transition-old(root),
+.ltr::view-transition-new(root),
+.left-to-right::view-transition-new(root) {
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.right-to-left::view-transition-old(root),
+.rtl::view-transition-new(root),
+.right-to-left::view-transition-new(root) {
+    left: 0;
+}
+
 .ltr .test51, .left-to-right .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -626,6 +626,22 @@ html.rtl .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+.ltr::view-transition-old(root),
+.ltr::view-transition-new(root) {
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.rtl::view-transition-new(root) {
+    left: 0;
+}
+
 .ltr.test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -626,6 +626,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"] > ::view-transition-old(root),
+[dir="ltr"] > ::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"] > ::view-transition-old(root),
+[dir="rtl"] > ::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] > .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -191,6 +191,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix.snapshot
@@ -191,6 +191,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -201,6 +201,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -191,6 +191,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -191,6 +191,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -582,6 +582,21 @@ html.rtl .test50, html.right-to-left .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.right-to-left::view-transition-old(root),
+.rtl::view-transition-new(root),
+.right-to-left::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix.snapshot
@@ -577,6 +577,19 @@ html.rtl .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.rtl::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/override/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -594,6 +594,21 @@ html.rtl .test50, html.right-to-left .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.right-to-left::view-transition-old(root),
+.rtl::view-transition-new(root),
+.right-to-left::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -577,6 +577,19 @@ html.rtl .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+.rtl::view-transition-old(root),
+.rtl::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -577,6 +577,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"] > ::view-transition-old(root),
+[dir="rtl"] > ::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-greedy-true.snapshot
@@ -634,6 +634,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -634,6 +634,22 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -642,6 +642,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -642,6 +642,22 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map.snapshot
@@ -634,6 +634,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true.snapshot
@@ -626,6 +626,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-greedy-true.snapshot
@@ -199,6 +199,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -199,6 +199,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -207,6 +207,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -207,6 +207,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map.snapshot
@@ -199,6 +199,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true.snapshot
@@ -191,6 +191,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-greedy-true.snapshot
@@ -585,6 +585,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -579,6 +579,19 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -593,6 +593,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -587,6 +587,19 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map.snapshot
@@ -585,6 +585,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true.snapshot
@@ -577,6 +577,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -709,6 +709,26 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-urls-true.snapshot
@@ -653,6 +653,26 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-rtl.snapshot
@@ -644,6 +644,26 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="rtl"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true.snapshot
@@ -644,6 +644,26 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -313,6 +313,13 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-urls-true.snapshot
@@ -269,6 +269,13 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-rtl.snapshot
@@ -269,6 +269,13 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true.snapshot
@@ -269,6 +269,13 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -694,6 +694,23 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 [dir] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-urls-true.snapshot
@@ -644,6 +644,23 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 [dir] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-rtl.snapshot
@@ -626,6 +626,23 @@ html[dir="ltr"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: 0;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 [dir] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true.snapshot
@@ -632,6 +632,23 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    height: 100%;
+}
+
+[dir]::view-transition-old(root),
+[dir]::view-transition-new(root) {
+    transform: scaleX(1.5);
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 [dir] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -638,6 +638,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -638,6 +638,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/combined/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-string-map-process-urls-true.snapshot
@@ -638,6 +638,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/combined/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-string-map-without-names-process-urls-true.snapshot
@@ -638,6 +638,22 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+}
+
+[dir="ltr"]::view-transition-old(root),
+[dir="ltr"]::view-transition-new(root) {
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    left: 0;
+}
+
 [dir="ltr"] .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -201,6 +201,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -201,6 +201,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/string-map/diff/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-string-map-process-urls-true.snapshot
@@ -201,6 +201,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/string-map/diff/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-string-map-without-names-process-urls-true.snapshot
@@ -201,6 +201,12 @@ html .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: none;
     border-right: 1px solid #FFF;

--- a/tests/__snapshots__/string-map/override/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -589,6 +589,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/override/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -589,6 +589,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/override/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-string-map-process-urls-true.snapshot
@@ -589,6 +589,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/__snapshots__/string-map/override/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-string-map-without-names-process-urls-true.snapshot
@@ -589,6 +589,19 @@ html[dir="rtl"] .test50 {
     right: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
+[dir="rtl"]::view-transition-old(root),
+[dir="rtl"]::view-transition-new(root) {
+    right: auto;
+    left: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
 }

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -433,6 +433,13 @@ html .test50 {
     left: 10px;
 }
 
+::view-transition-old(root),
+::view-transition-new(root) {
+    transform: scaleX(1.5);
+    height: 100%;
+    right: 0;
+}
+
 .test51 {
     border-left: 1px solid #FFF;
     border: none;

--- a/tests/prefixes.test.ts
+++ b/tests/prefixes.test.ts
@@ -79,7 +79,11 @@ runTests({}, (pluginOptions: PluginOptions): void => {
 
         it('prefixSelectorTransformer with custom ltrPrefix and rtlPrefix', (): void => {
             const transformer = (prefix: string, selector: string) => {
-                if (!selector.startsWith('html') && selector.indexOf(':root') < 0) {
+                if (
+                    !selector.startsWith('html') &&
+                    !selector.startsWith('::view-transition') &&
+                    selector.indexOf(':root') < 0
+                ) {
                     return `${prefix}${selector}`;
                 }
             };


### PR DESCRIPTION
This pull request add support for prefixes in [view-transition pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API#customizing_your_animations).

>Note: this is an experimental technology and an eye should be kept on it because it can be removed or changed in future proposals.