### PR TITLE
Fix raw directive with universal selector

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,7 +11,7 @@ export const ANIMATION_PROP = 'animation';
 export const ANIMATION_NAME_PROP = 'animation-name';
 export const RTL_COMMENT_REGEXP = /rtl:/;
 export const RTL_COMMENT_IGNORE_REGEXP = /rtl:ignore/;
-export const RTL_CONTROL_DIRECTIVE_REG_EXP = /^\/\*!? *rtl:?(begin|end)?:(\w+):?([^*]*?) *\*\/$/;
+export const RTL_CONTROL_DIRECTIVE_REG_EXP = /^\/\*!? *rtl:?(begin|end)?:(\w+):?([\s\S]*?) *\*\/$/;
 export const FLIP_PROPERTY_REGEXP = /(right|left)/i;
 export const HTML_SELECTOR_REGEXP = /^(html)(?=\W|$)/;
 export const ROOT_SELECTOR_REGEXP = /(:root)(?=\W|$)/;

--- a/tests/__snapshots__/basic-options/combined/basic.snapshot
+++ b/tests/__snapshots__/basic-options/combined/basic.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] Basic Options Tests:  Basic 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/basic-options/combined/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/process-keyframes-true.snapshot
@@ -466,6 +466,10 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/basic-options/combined/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/process-url-true.snapshot
@@ -442,6 +442,10 @@ exports[`[[Mode: combined]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/basic-options/combined/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/source-rtl-and-process-keyframes-true.snapshot
@@ -466,6 +466,10 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/basic-options/combined/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/combined/source-rtl.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/basic-options/combined/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/use-calc-true.snapshot
@@ -431,6 +431,10 @@ exports[`[[Mode: combined]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/basic-options/diff/basic.snapshot
+++ b/tests/__snapshots__/basic-options/diff/basic.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] Basic Options Tests:  Basic 1`] = `
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/basic-options/diff/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/process-keyframes-true.snapshot
@@ -152,6 +152,10 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processKeyFrames: true} 1`] = `
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/basic-options/diff/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/process-url-true.snapshot
@@ -132,6 +132,10 @@ exports[`[[Mode: diff]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/basic-options/diff/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/source-rtl-and-process-keyframes-true.snapshot
@@ -152,6 +152,10 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl, processKeyFrames: tr
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/basic-options/diff/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/diff/source-rtl.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/basic-options/diff/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/use-calc-true.snapshot
@@ -123,6 +123,10 @@ exports[`[[Mode: diff]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/basic-options/override/basic.snapshot
+++ b/tests/__snapshots__/basic-options/override/basic.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] Basic Options Tests:  Basic 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/basic-options/override/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/process-keyframes-true.snapshot
@@ -425,6 +425,10 @@ exports[`[[Mode: override]] Basic Options Tests:  {processKeyFrames: true} 1`] =
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/basic-options/override/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/process-url-true.snapshot
@@ -407,6 +407,10 @@ exports[`[[Mode: override]] Basic Options Tests:  {processUrls: true} 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/basic-options/override/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/source-rtl-and-process-keyframes-true.snapshot
@@ -425,6 +425,10 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl, processKeyFrames
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/basic-options/override/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/override/source-rtl.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] Basic Options Tests:  {source: rtl} 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/basic-options/override/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/use-calc-true.snapshot
@@ -396,6 +396,10 @@ exports[`[[Mode: override]] Basic Options Tests:  {useCalc: true} 1`] = `
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -440,6 +440,10 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
     transform: translate(10px, 20px);
 }
 
+.rtl *, .right-to-left * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
     transform: translate(10px, 20px);
 }
 
+.rtl * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -452,6 +452,10 @@ exports[`[[Mode: combined]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
     transform: translate(10px, 20px);
 }
 
+.rtl *, .right-to-left * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with cust
     transform: translate(10px, 20px);
 }
 
+.rtl * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] > * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix properti
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] = `
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -132,6 +132,10 @@ exports[`[[Mode: diff]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bothPr
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with custom l
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] Prefixes Tests:  prefixSelectorTransformer with default 
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -400,6 +400,10 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix prop
     transform: translate(10px, 20px);
 }
 
+.rtl *, .right-to-left * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix and rtlPrefix 1`] 
     transform: translate(10px, 20px);
 }
 
+.rtl * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/prefixes/override/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -412,6 +412,10 @@ exports[`[[Mode: override]] Prefixes Tests:  custom ltrPrefix, rtlPrefix, and bo
     transform: translate(10px, 20px);
 }
 
+.rtl *, .right-to-left * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with cust
     transform: translate(10px, 20px);
 }
 
+.rtl * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] Prefixes Tests:  prefixSelectorTransformer with defa
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] > * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-greedy-true.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] processRuleNames Tests:  processRuleNames: true, gre
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] processRuleNames Tests:  processRuleNames: true, wit
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -438,6 +438,10 @@ exports[`[[Mode: combined]] processRuleNames Tests:  processRuleNames: true with
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -438,6 +438,10 @@ exports[`[[Mode: combined]] processRuleNames Tests:  processRuleNames: true with
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map.snapshot
@@ -438,6 +438,10 @@ exports[`[[Mode: combined]] processRuleNames Tests:  processRuleNames: true with
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true.snapshot
@@ -430,6 +430,10 @@ exports[`[[Mode: combined]] processRuleNames Tests:  processRuleNames: true 1`] 
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-greedy-true.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] processRuleNames Tests:  processRuleNames: true, greedy:
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] processRuleNames Tests:  processRuleNames: true, with so
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -130,6 +130,10 @@ exports[`[[Mode: diff]] processRuleNames Tests:  processRuleNames: true with cus
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -130,6 +130,10 @@ exports[`[[Mode: diff]] processRuleNames Tests:  processRuleNames: true with cus
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map.snapshot
@@ -130,6 +130,10 @@ exports[`[[Mode: diff]] processRuleNames Tests:  processRuleNames: true with cus
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true.snapshot
@@ -122,6 +122,10 @@ exports[`[[Mode: diff]] processRuleNames Tests:  processRuleNames: true 1`] = `
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-greedy-true.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] processRuleNames Tests:  processRuleNames: true, gre
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] processRuleNames Tests:  processRuleNames: true, wit
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -403,6 +403,10 @@ exports[`[[Mode: override]] processRuleNames Tests:  processRuleNames: true with
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -403,6 +403,10 @@ exports[`[[Mode: override]] processRuleNames Tests:  processRuleNames: true with
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map.snapshot
@@ -403,6 +403,10 @@ exports[`[[Mode: override]] processRuleNames Tests:  processRuleNames: true with
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true.snapshot
@@ -395,6 +395,10 @@ exports[`[[Mode: override]] processRuleNames Tests:  processRuleNames: true 1`] 
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -478,6 +478,10 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-urls-true.snapshot
@@ -454,6 +454,10 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-rtl.snapshot
@@ -445,6 +445,10 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true.snapshot
@@ -445,6 +445,10 @@ exports[`[[Mode: combined]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -209,6 +209,10 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-urls-true.snapshot
@@ -189,6 +189,10 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-rtl.snapshot
@@ -189,6 +189,10 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} and
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true.snapshot
@@ -189,6 +189,10 @@ exports[`[[Mode: diff]] safeBothPrefix Option Tests:  {safeBothPrefix: true} 1`]
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -459,6 +459,10 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-urls-true.snapshot
@@ -441,6 +441,10 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-rtl.snapshot
@@ -429,6 +429,10 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="ltr"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true.snapshot
@@ -429,6 +429,10 @@ exports[`[[Mode: override]] safeBothPrefix Option Tests:  {safeBothPrefix: true}
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -442,6 +442,10 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -442,6 +442,10 @@ exports[`[[Mode: combined]] String Map Tests:  custom no-valid string map and pr
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/string-map/combined/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-string-map-process-urls-true.snapshot
@@ -442,6 +442,10 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map and processUrls
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/string-map/combined/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-string-map-without-names-process-urls-true.snapshot
@@ -442,6 +442,10 @@ exports[`[[Mode: combined]] String Map Tests:  custom string map without names a
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     width: 100%;

--- a/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -132,6 +132,10 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -132,6 +132,10 @@ exports[`[[Mode: diff]] String Map Tests:  custom no-valid string map and proces
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/string-map/diff/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-string-map-process-urls-true.snapshot
@@ -132,6 +132,10 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map and processUrls: tr
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/string-map/diff/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-string-map-without-names-process-urls-true.snapshot
@@ -132,6 +132,10 @@ exports[`[[Mode: diff]] String Map Tests:  custom string map without names and p
     transform: translate(10px, 20px);
 }
 
+* {
+    margin: 0;
+}
+
 .test36 {
     border-left: none;
     border-right: 1px solid #666;

--- a/tests/__snapshots__/string-map/override/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -407,6 +407,10 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/string-map/override/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -407,6 +407,10 @@ exports[`[[Mode: override]] String Map Tests:  custom no-valid string map and pr
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/string-map/override/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-string-map-process-urls-true.snapshot
@@ -407,6 +407,10 @@ exports[`[[Mode: override]] String Map Tests:  custom string map and processUrls
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/__snapshots__/string-map/override/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-string-map-without-names-process-urls-true.snapshot
@@ -407,6 +407,10 @@ exports[`[[Mode: override]] String Map Tests:  custom string map without names a
     transform: translate(10px, 20px);
 }
 
+[dir="rtl"] * {
+    margin: 0;
+}
+
 .test36 {
     color: #FFF;
     border-left: 1px solid #666;

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -299,6 +299,10 @@
 }
 */
 
+/*rtl:raw:* {
+    margin: 0;
+}*/
+
 /*rtl:source:rtl*/
 .test36 {
     color: #FFF;

--- a/tests/prefixes.test.ts
+++ b/tests/prefixes.test.ts
@@ -82,6 +82,7 @@ runTests({}, (pluginOptions: PluginOptions): void => {
                 if (
                     !selector.startsWith('html') &&
                     !selector.startsWith('::view-transition') &&
+                    !selector.startsWith('*') &&
                     selector.indexOf(':root') < 0
                 ) {
                     return `${prefix}${selector}`;


### PR DESCRIPTION
This pull request fixes the `raw` directive when the string contains `*` character.