### PR TITLE
Simplify type checking using predicates

### DIFF
--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -16,11 +16,13 @@ import {
     StringMap,
     PluginStringMap
 } from '@types';
+import { REG_EXP_CHARACTERS_REG_EXP, LAST_WORD_CHARACTER_REG_EXP } from '@constants';
 import {
-    TYPEOF,
-    REG_EXP_CHARACTERS_REG_EXP,
-    LAST_WORD_CHARACTER_REG_EXP
-} from '@constants';
+    isBoolean,
+    isFunction,
+    isNumber,
+    isString
+} from '@utilities/predicates';
 
 interface Store {
     options: PluginOptionsNormalized;
@@ -75,11 +77,11 @@ const ModeValuesArray = Object.keys(Mode).map((prop: ModeValue) => Mode[prop] as
 const SourceValuesArray = Object.keys(Source).map((prop: SourceValue) => Source[prop] as SourceValue);
 
 const isNotStringOrStringArray = (value: strings): boolean => {
-    if (typeof value !== 'string' && !Array.isArray(value)) {
+    if (!isString(value) && !Array.isArray(value)) {
         return true;
     }
     if (Array.isArray(value)) {
-        return value.some((item: string): boolean => typeof item !== 'string');
+        return value.some((item: string): boolean => !isString(item));
     }
     return false;
 };
@@ -103,23 +105,23 @@ const isNotAcceptedStringMap = (stringMap: PluginStringMap[]): boolean => {
 const isAcceptedProcessDeclarationPlugins = (plugins: DeclarationPlugin[]): boolean =>
     Array.isArray(plugins)
     && plugins.every((plugin: DeclarationPlugin) =>
-        typeof plugin.name == TYPEOF.STRING
-            && typeof plugin.priority == TYPEOF.NUMBER
+        isString(plugin.name)
+            && isNumber(plugin.priority)
             && Array.isArray(plugin.processors)
             && plugin.processors.every((processor: DeclarationPluginProcessor) =>
                 processor.expr instanceof RegExp
-                && typeof processor.action === TYPEOF.FUNCTION
+                && isFunction(processor.action)
             )
     );
 
 const isObjectWithStringKeys = (obj: Record<string, unknown>): boolean =>
     !Object.entries(obj).some(
         (entry: [string, unknown]): boolean =>
-            typeof entry[1] !== 'string'
+            !isString(entry[1])
     );
 
 const spreadArrayOfStrings = (arr: string[], item: strings): string[] => {
-    return typeof item === 'string'
+    return isString(item)
         ? [...arr, item]
         : [...arr, ...item];
 };
@@ -180,10 +182,10 @@ const normalizeOptions = (options: PluginOptions): PluginOptionsNormalized => {
     if (options.source && SourceValuesArray.includes(options.source)) {
         returnOptions.source = options.source;
     }
-    if (typeof options.ignorePrefixedRules === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.ignorePrefixedRules)) {
         returnOptions.ignorePrefixedRules = options.ignorePrefixedRules;
     }
-    if (typeof options.greedy === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.greedy)) {
         returnOptions.greedy = options.greedy;
     }
     if (!isNotStringOrStringArray(options.ltrPrefix)) {
@@ -195,25 +197,25 @@ const normalizeOptions = (options: PluginOptions): PluginOptionsNormalized => {
     if (!isNotStringOrStringArray(options.bothPrefix)) {
         returnOptions.bothPrefix = options.bothPrefix;
     }
-    if (typeof options.prefixSelectorTransformer === TYPEOF.FUNCTION) {
+    if (isFunction(options.prefixSelectorTransformer)) {
         returnOptions.prefixSelectorTransformer = options.prefixSelectorTransformer;
     }
-    if (typeof options.safeBothPrefix === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.safeBothPrefix)) {
         returnOptions.safeBothPrefix = options.safeBothPrefix;
     }
-    if (typeof options.processUrls === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.processUrls)) {
         returnOptions.processUrls = options.processUrls;
     }
-    if (typeof options.processRuleNames === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.processRuleNames)) {
         returnOptions.processRuleNames = options.processRuleNames;
     }
-    if (typeof options.processKeyFrames === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.processKeyFrames)) {
         returnOptions.processKeyFrames = options.processKeyFrames;
     }
-    if (typeof options.processEnv === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.processEnv)) {
         returnOptions.processEnv = options.processEnv;
     }
-    if (typeof options.useCalc === TYPEOF.BOOLEAN) {
+    if (isBoolean(options.useCalc)) {
         returnOptions.useCalc = options.useCalc;
     }
     if (!isNotAcceptedStringMap(options.stringMap)) {

--- a/src/parsers/declarations.ts
+++ b/src/parsers/declarations.ts
@@ -33,6 +33,7 @@ import {
     hasMirrorDeclaration,
     hasSameUpcomingDeclarationWithoutMirror
 } from '@utilities/declarations';
+import { isDeclaration } from '@utilities/predicates';
 import { walkContainer } from '@utilities/containers';
 import {
     cleanRuleRawsBefore,
@@ -70,13 +71,12 @@ export const parseDeclarations = (
     const ruleSafe = ruleFlipped.clone();
 
     const declarationHashMap = Array.prototype.reduce.call(rule.nodes, (obj: DeclarationHashMap, node: Node): DeclarationHashMap => {
-        if (node.type === TYPE.DECLARATION) {
-            const decl = node as Declaration;
-            const index = rule.index(decl);
-            obj[decl.prop] = obj[decl.prop] || { ignore: false, indexes: {} };
-            obj[decl.prop].indexes[index] = {
-                decl,
-                value: decl.value.trim(),
+        if (isDeclaration(node)) {
+            const index = rule.index(node);
+            obj[node.prop] = obj[node.prop] || { ignore: false, indexes: {} };
+            obj[node.prop].indexes[index] = {
+                decl: node,
+                value: node.value.trim(),
                 ignore: false
             };
         }
@@ -144,7 +144,7 @@ export const parseDeclarations = (
             controlDirectives[controlDirective.directive] = controlDirective;
 
         },
-        (node: Node): void => {
+        (decl: Declaration): void => {
 
             if ( checkDirective(controlDirectives, CONTROL_DIRECTIVE.IGNORE) ) {
                 return;
@@ -152,7 +152,6 @@ export const parseDeclarations = (
 
             const processUrlDirective = checkDirective(controlDirectives, CONTROL_DIRECTIVE.URLS);
 
-            const decl = node as Declaration;
             const declString = `${decl.toString()};`;
             const declFlippedString = rtlcss.process(declString, {
                 processUrls: processUrls || processUrlDirective || rename,

--- a/src/parsers/rules.ts
+++ b/src/parsers/rules.ts
@@ -1,6 +1,5 @@
 import postcss, {
     Container,
-    Node,
     Rule,
     Comment
 } from 'postcss';
@@ -21,9 +20,9 @@ import { cleanRuleRawsBefore } from '@utilities/rules';
 import { addSelectorPrefixes, hasSelectorsPrefixed } from '@utilities/selectors';
 import { parseDeclarations } from './declarations';
 
-const addToIgnoreRulesInDiffMode = (node: Node): void => {
+const addToIgnoreRulesInDiffMode = (rule: Rule): void => {
     if (store.options.mode === Mode.diff) {
-        store.rulesToRemove.push(node as Rule);
+        store.rulesToRemove.push(rule);
     }
 };
 
@@ -92,25 +91,23 @@ export const parseRules = (
             controlDirectives[controlDirective.directive] = controlDirective;
 
         },
-        (node: Node): void => {
+        (node: Rule): void => {
 
             if ( checkDirective(controlDirectives, CONTROL_DIRECTIVE.IGNORE) ) {
                 addToIgnoreRulesInDiffMode(node);
                 return;
             }
-        
-            const rule = node as Rule;
             
             const sourceDirectiveValue = getSourceDirectiveValue(
                 controlDirectives,
                 parentSourceDirective
             );
 
-            if (hasSelectorsPrefixed(rule)) {
-                addToIgnoreRulesInDiffMode(rule);
+            if (hasSelectorsPrefixed(node)) {
+                addToIgnoreRulesInDiffMode(node);
             } else {
                 parseDeclarations(
-                    rule,
+                    node,
                     hasParentRule,
                     sourceDirectiveValue,
                     checkDirective(controlDirectives, CONTROL_DIRECTIVE.RULES),
@@ -119,7 +116,7 @@ export const parseRules = (
             }
             
             parseRules(
-                rule,
+                node,
                 parentSourceDirective,
                 true
             );

--- a/src/utilities/clean.ts
+++ b/src/utilities/clean.ts
@@ -5,9 +5,14 @@ import {
     AtRule
 } from 'postcss';
 import { store } from '@data/store';
-import { TYPE, KEYFRAMES_NAME } from '@constants';
+import { KEYFRAMES_NAME } from '@constants';
 import { Mode, RulesObject } from '@types';
 import { vendor } from '@utilities/vendor';
+import {
+    isAtRule,
+    isComment,
+    isRule
+} from '@utilities/predicates';
 import { ruleHasChildren, cleanRuleRawsBefore } from '@utilities/rules';
 
 export const clean = (css: Container): void => {
@@ -35,31 +40,31 @@ export const clean = (css: Container): void => {
     }
     css.walk((node: Node): void => {
         if (mode === Mode.diff) {
-            if (node.type === TYPE.COMMENT) {
+            if (isComment(node)) {
                 node.remove();
             } else if (
-                node.type === TYPE.AT_RULE &&
+                isAtRule(node) &&
                 !processKeyFrames &&
-                vendor.unprefixed((node as AtRule).name) === KEYFRAMES_NAME
+                vendor.unprefixed(node.name) === KEYFRAMES_NAME
             ) {
                 node.remove();
             }
         }
         if (
             (
-                node.type === TYPE.RULE ||
-                node.type === TYPE.AT_RULE
+                isRule(node) ||
+                isAtRule(node)
             ) &&
-            !!(node as Container).nodes
+            !!node.nodes
         ) {
-            if (!ruleHasChildren(node as Container)) {
+            if (!ruleHasChildren(node)) {
                 if (mode === Mode.diff) {
                     node.remove();
                 }
             } else {
                 const prev = node.prev();
                 if (prev) {
-                    if (prev.type !== TYPE.COMMENT) {
+                    if (!isComment(prev)) {
                         cleanRuleRawsBefore(node);
                     }
                 } else {

--- a/src/utilities/containers.ts
+++ b/src/utilities/containers.ts
@@ -1,11 +1,11 @@
 import {
     Comment,
     Container,
-    Node,
+    Node
 } from 'postcss';
 import { ControlDirective } from '@types';
-import { TYPE } from '@constants';
 import { getControlDirective } from '@utilities/directives';
+import { isComment } from '@utilities/predicates';
 
 type WalkContainerControlDirectiveCallback = (comment: Comment, controlDirective: ControlDirective) => void;
 type WalkContainerNodeCallback = (node: Node) => void;
@@ -19,15 +19,14 @@ export const walkContainer = (
 
     container.each((node: Node): undefined | false => {
 
-        if ( node.type !== TYPE.COMMENT && !filter.includes(node.type) ) return;
+        if ( !isComment(node) && !filter.includes(node.type) ) return;
 
-        if (node.type === TYPE.COMMENT) {
+        if (isComment(node)) {
 
-            const comment = node as Comment;
-            const controlDirective = getControlDirective(comment);
+            const controlDirective = getControlDirective(node);
             
             if (controlDirective) {
-                directiveCallback(comment, controlDirective);
+                directiveCallback(node, controlDirective);
             }
 
         } else {

--- a/src/utilities/declarations.ts
+++ b/src/utilities/declarations.ts
@@ -3,11 +3,8 @@ import {
     DeclarationsData,
     DeclarationHashMap
 } from '@types';
-import {
-    TYPE,
-    RTL_COMMENT_IGNORE_REGEXP,
-    FLIP_PROPERTY_REGEXP
-} from '@constants';
+import { RTL_COMMENT_IGNORE_REGEXP, FLIP_PROPERTY_REGEXP } from '@constants';
+import { isComment } from '@utilities/predicates';
 import shorthandDeclarationsJson from '@data/shorthand-declarations.json';
 import logicalDeclarationsJson from '@data/logical-declarations.json';
 import notShorthandDeclarationsJson from '@data/not-shorthand-declarations.json';
@@ -80,7 +77,7 @@ Object.keys(initialValuesData).forEach((value: string): void => {
 const appendDeclarationToRule = (decl: Declaration, rule: Rule): void => {
     const declClone = decl.clone();
     const declPrev = decl.prev();
-    if (declPrev && declPrev.type === TYPE.COMMENT) {
+    if (declPrev && isComment(declPrev)) {
         const commentClone = declPrev.clone();
         rule.append(commentClone);
         declPrev.remove();

--- a/src/utilities/predicates.ts
+++ b/src/utilities/predicates.ts
@@ -1,0 +1,20 @@
+import {
+    AtRule,
+    Comment,
+    Declaration,
+    Node,
+    Rule
+} from 'postcss';
+import { TYPE, TYPEOF } from '@constants';
+
+type FunctionType = (...args: unknown[]) => unknown;
+
+export const isAtRule = (node: Node): node is AtRule => node.type === TYPE.AT_RULE;
+export const isComment = (node: Node): node is Comment => node.type === TYPE.COMMENT;
+export const isDeclaration = (node: Node): node is Declaration => node.type === TYPE.DECLARATION;
+export const isRule = (node: Node): node is Rule => node.type === TYPE.RULE;
+
+export const isBoolean = (value: unknown): value is boolean => typeof value === TYPEOF.BOOLEAN;
+export const isFunction = (value: unknown): value is FunctionType => typeof value === TYPEOF.FUNCTION;
+export const isNumber = (value: unknown): value is number => typeof value === TYPEOF.NUMBER;
+export const isString = (value: unknown): value is string => typeof value === TYPEOF.STRING;

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -3,15 +3,15 @@ import { strings, Mode, Source } from '@types';
 import {
     HTML_SELECTOR_REGEXP,
     ROOT_SELECTOR_REGEXP,
-    VIEW_TRANSITION_REGEXP,
-    TYPEOF
+    VIEW_TRANSITION_REGEXP
 } from '@constants';
 import { store } from '@data/store';
+import { isString } from '@utilities/predicates';
 
 const addPrefix = (prefix: string, selector: string): string => {
     if (store.options.prefixSelectorTransformer) {
         const transformedSelector = store.options.prefixSelectorTransformer(prefix, selector);
-        if (transformedSelector && typeof transformedSelector === TYPEOF.STRING) {
+        if (transformedSelector && isString(transformedSelector)) {
             return transformedSelector;
         }
     }
@@ -28,7 +28,7 @@ const addPrefix = (prefix: string, selector: string): string => {
 };
 
 export const addSelectorPrefixes = (rule: Rule, prefixes: strings): void => {
-    rule.selectors = typeof prefixes === 'string'
+    rule.selectors = isString(prefixes)
         ? rule.selectors.map((selector: string): string => {
             if (store.rulesPrefixRegExp.test(selector)) {
                 return selector;


### PR DESCRIPTION
This pull request simplifies the code to check for the `postcss` node types and the typeof of multiple variables using `TypeScript` predicates.