### PR TITLE
Support for nested at-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.5.0] - 2024-09-28
+
+- Support for nested at-rules
+
 ## [5.4.0] - 2024-09-01
 
 - Update `RTLCSS` to version `4.3.0`

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -4,6 +4,8 @@ import {
     Declaration
 } from 'postcss';
 
+export type DeclarationContainer = Rule | AtRule;
+
 export enum Mode {
     combined = 'combined',
     override = 'override',

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -1,7 +1,8 @@
-import { Rule, AtRule } from 'postcss';
+import { AtRule } from 'postcss';
 import {
     PluginOptions,
     PluginOptionsNormalized,
+    DeclarationContainer,
     DeclarationPlugin,
     DeclarationPluginProcessor,
     AtRulesObject,
@@ -31,7 +32,7 @@ interface Store {
     keyframesStringMap: AtRulesStringMap;
     keyframesRegExp: RegExp;
     rules: RulesObject[];
-    rulesToRemove: Rule[];
+    containersToRemove: DeclarationContainer[];
     rulesPrefixRegExp: RegExp;
     unmodifiedRules: UnmodifiedRulesObject[];
 }
@@ -169,7 +170,7 @@ const store: Store = {
     keyframesStringMap: {},
     keyframesRegExp: defaultRegExp,
     rules: [],
-    rulesToRemove: [],
+    containersToRemove: [],
     rulesPrefixRegExp: defaultRegExp,
     unmodifiedRules: []
 };
@@ -248,7 +249,7 @@ const initStore = (options: PluginOptions): void => {
     store.keyframesStringMap = {};
     store.keyframesRegExp = defaultRegExp;
     store.rules = [];
-    store.rulesToRemove = [];
+    store.containersToRemove = [];
     store.rulesPrefixRegExp = createRulesPrefixesRegExp(store.options);
     store.unmodifiedRules = [];
 };

--- a/src/parsers/atrules.ts
+++ b/src/parsers/atrules.ts
@@ -29,8 +29,13 @@ import {
 import { isAtRule } from '@utilities/predicates';
 import { vendor } from '@utilities/vendor';
 import { parseRules } from '@parsers/rules';
+import { parseDeclarations } from './declarations';
 
-export const parseAtRules = (container: Container): void => {
+export const parseAtRules = (
+    container: Container,
+    parentSourceDirective: string = undefined,
+    hasParentRule = false
+): void => {
 
     const controlDirectives: Record<string, ControlDirective> = {};
 
@@ -56,11 +61,35 @@ export const parseAtRules = (container: Container): void => {
 
             if (vendor.unprefixed(node.name) === KEYFRAMES_NAME) return;
 
-            const sourceDirectiveValue = getSourceDirectiveValue(controlDirectives);
+            const sourceDirectiveValue = getSourceDirectiveValue(
+                controlDirectives,
+                parentSourceDirective
+            );
 
-            parseRules(node, sourceDirectiveValue);
+            if (
+                hasParentRule &&
+                node.nodes
+            ) {
+                parseDeclarations(
+                    node,
+                    hasParentRule,
+                    sourceDirectiveValue,
+                    checkDirective(controlDirectives, CONTROL_DIRECTIVE.RULES),
+                    checkDirective(controlDirectives, CONTROL_DIRECTIVE.URLS)
+                );
+            }
 
-            parseAtRules(node);
+            parseAtRules(
+                node,
+                parentSourceDirective,
+                hasParentRule
+            );
+
+            parseRules(
+                node,
+                sourceDirectiveValue,
+                hasParentRule
+            );
 
         }
     );

--- a/src/parsers/rules.ts
+++ b/src/parsers/rules.ts
@@ -18,18 +18,19 @@ import {
 import { walkContainer } from '@utilities/containers';
 import { cleanRuleRawsBefore } from '@utilities/rules';
 import { addSelectorPrefixes, hasSelectorsPrefixed } from '@utilities/selectors';
+import { parseAtRules } from './atrules';
 import { parseDeclarations } from './declarations';
 
 const addToIgnoreRulesInDiffMode = (rule: Rule): void => {
     if (store.options.mode === Mode.diff) {
-        store.rulesToRemove.push(rule);
+        store.containersToRemove.push(rule);
     }
 };
 
 export const parseRules = (
     container: Container,
     parentSourceDirective: string = undefined,
-    hasParentRule = false,
+    hasParentRule = false
 ): void => {
 
     const controlDirectives: Record<string, ControlDirective> = {};
@@ -114,6 +115,12 @@ export const parseRules = (
                     checkDirective(controlDirectives, CONTROL_DIRECTIVE.URLS)
                 );
             }
+
+            parseAtRules(
+                node,
+                parentSourceDirective,
+                true
+            );
             
             parseRules(
                 node,

--- a/src/utilities/clean.ts
+++ b/src/utilities/clean.ts
@@ -19,7 +19,7 @@ export const clean = (css: Container): void => {
     const {
         options,
         rules,
-        rulesToRemove,
+        containersToRemove,
         keyframes,
         keyframesToRemove
     } = store;
@@ -28,7 +28,7 @@ export const clean = (css: Container): void => {
         rules.forEach((rulesObject: RulesObject): void => {
             rulesObject.rule.remove();
         });
-        rulesToRemove.forEach((rule: Rule) => {
+        containersToRemove.forEach((rule: Rule) => {
             rule.remove();
         });
         keyframes.forEach(({atRule}): void => {

--- a/src/utilities/declarations.ts
+++ b/src/utilities/declarations.ts
@@ -1,5 +1,6 @@
-import { Rule, Declaration } from 'postcss';
+import { Declaration } from 'postcss';
 import {
+    DeclarationContainer,
     DeclarationsData,
     DeclarationHashMap
 } from '@types';
@@ -74,15 +75,15 @@ Object.keys(initialValuesData).forEach((value: string): void => {
     });
 });
 
-const appendDeclarationToRule = (decl: Declaration, rule: Rule): void => {
+const appendDeclarationToRule = (decl: Declaration, container: DeclarationContainer): void => {
     const declClone = decl.clone();
     const declPrev = decl.prev();
     if (declPrev && isComment(declPrev)) {
         const commentClone = declPrev.clone();
-        rule.append(commentClone);
+        container.append(commentClone);
         declPrev.remove();
     }
-    rule.append(declClone);
+    container.append(declClone);
 };
 
 const hasIgnoreDirectiveInRaws = (decl: Declaration): boolean => {
@@ -98,12 +99,12 @@ const checkOverrides = (decl: string, decls: string[]): boolean => {
 };
 
 const hasSameUpcomingDeclarationWithoutMirror = (
-    rule: Rule,
+    container: DeclarationContainer,
     decl: Declaration,
     declFlipped: Declaration,
     declarationHashMap: DeclarationHashMap
 ): boolean => {
-    const index = rule.index(decl);
+    const index = container.index(decl);
     const hashMapData = declarationHashMap[decl.prop];
     const indexes = Object.keys(hashMapData.indexes).map(Number).sort();
     if (indexes.length === 1) {
@@ -131,11 +132,11 @@ const hasSameUpcomingDeclarationWithoutMirror = (
 };
 
 const hasSameUpcomingDeclaration = (
-    rule: Rule,
+    container: DeclarationContainer,
     decl: Declaration,
     declarationHashMap: DeclarationHashMap
 ): boolean => {
-    const index = rule.index(decl);
+    const index = container.index(decl);
     const indexes = Object.keys(declarationHashMap[decl.prop].indexes).map(Number);
     if (indexes.length === 1) {
         return false;
@@ -144,7 +145,7 @@ const hasSameUpcomingDeclaration = (
 };
 
 const hasMirrorDeclaration = (
-    rule: Rule,
+    container: DeclarationContainer,
     declFlipped: Declaration,
     declarationHashMap: DeclarationHashMap
 ): boolean => {
@@ -153,7 +154,7 @@ const hasMirrorDeclaration = (
         return entries.some((entry) => {
             return (
                 entry[1].value === declFlipped.value.trim() &&
-                !hasSameUpcomingDeclaration(rule, entry[1].decl, declarationHashMap)
+                !hasSameUpcomingDeclaration(container, entry[1].decl, declarationHashMap)
             );
         });
     }

--- a/src/utilities/predicates.ts
+++ b/src/utilities/predicates.ts
@@ -5,6 +5,7 @@ import {
     Node,
     Rule
 } from 'postcss';
+import { DeclarationContainer } from '@types';
 import { TYPE, TYPEOF } from '@constants';
 
 type FunctionType = (...args: unknown[]) => unknown;
@@ -13,6 +14,7 @@ export const isAtRule = (node: Node): node is AtRule => node.type === TYPE.AT_RU
 export const isComment = (node: Node): node is Comment => node.type === TYPE.COMMENT;
 export const isDeclaration = (node: Node): node is Declaration => node.type === TYPE.DECLARATION;
 export const isRule = (node: Node): node is Rule => node.type === TYPE.RULE;
+export const isDeclarationContainer = (node: Node): node is DeclarationContainer => isRule(node) || isAtRule(node);
 
 export const isBoolean = (value: unknown): value is boolean => typeof value === TYPEOF.BOOLEAN;
 export const isFunction = (value: unknown): value is FunctionType => typeof value === TYPEOF.FUNCTION;

--- a/tests/__snapshots__/nested-rules/combined/source-ltr-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-ltr-process-rule-names-true.snapshot
@@ -165,13 +165,35 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} processRuleNames:
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
         }
     }
 }
 
 [dir="ltr"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: 10px;
+        }
+    }
+
     .test13 {
         text-align: right;
     }
@@ -186,6 +208,18 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} processRuleNames:
 }
 
 [dir="rtl"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/combined/source-ltr.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-ltr.snapshot
@@ -165,7 +165,17 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
         }
     }
@@ -180,12 +190,36 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
 }
 
 [dir="ltr"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: 10px;
+        }
+    }
+
     .test13 {
         text-align: right;
     }
 }
 
 [dir="rtl"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/combined/source-rtl-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-rtl-process-rule-names-true.snapshot
@@ -165,13 +165,35 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} processRuleNames:
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
         }
     }
 }
 
 [dir="rtl"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: 10px;
+        }
+    }
+
     .test13 {
         text-align: right;
     }
@@ -186,6 +208,18 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} processRuleNames:
 }
 
 [dir="ltr"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/combined/source-rtl.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-rtl.snapshot
@@ -165,7 +165,17 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
         }
     }
@@ -180,12 +190,36 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
 }
 
 [dir="rtl"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: 10px;
+        }
+    }
+
     .test13 {
         text-align: right;
     }
 }
 
 [dir="ltr"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/diff/source-ltr-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-ltr-process-rule-names-true.snapshot
@@ -70,6 +70,19 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: ltr} processRuleNames: tru
 }
 
 .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/diff/source-ltr.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-ltr.snapshot
@@ -70,6 +70,19 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: ltr} 1`] = `
 }
 
 .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/diff/source-rtl-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-rtl-process-rule-names-true.snapshot
@@ -70,6 +70,19 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: rtl} processRuleNames: tru
 }
 
 .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/diff/source-rtl.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-rtl.snapshot
@@ -70,6 +70,19 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: rtl} 1`] = `
 }
 
 .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/override/source-ltr-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-ltr-process-rule-names-true.snapshot
@@ -140,8 +140,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} processRuleNames:
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
+            left: 10px;
         }
     }
 
@@ -159,6 +171,19 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} processRuleNames:
 }
 
 [dir="rtl"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/override/source-ltr.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-ltr.snapshot
@@ -140,8 +140,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
+            left: 10px;
         }
     }
 
@@ -159,6 +171,19 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
 }
 
 [dir="rtl"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/override/source-rtl-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-rtl-process-rule-names-true.snapshot
@@ -140,8 +140,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} processRuleNames:
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
+            left: 10px;
         }
     }
 
@@ -159,6 +171,19 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} processRuleNames:
 }
 
 [dir="ltr"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/__snapshots__/nested-rules/override/source-rtl.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-rtl.snapshot
@@ -140,8 +140,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+                padding: 10px 5px 20px 2px;
+            }
+        }
+
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
+            left: 10px;
         }
     }
 
@@ -159,6 +171,19 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
 }
 
 [dir="ltr"] .test11 {
+    .test12 {
+        @media (orientation: landscape) {
+            @media (min-width: 1024px) {
+                padding: 10px 2px 20px 5px;
+            }
+        }
+
+        @media screen and (min-width: 800px) {
+            left: auto;
+            right: 10px;
+        }
+    }
+
     .test13 {
         text-align: left;
     }

--- a/tests/css/input-nested.scss
+++ b/tests/css/input-nested.scss
@@ -68,8 +68,18 @@
 
 .test11 {
     .test12 {
+        @media (orientation: landscape) {
+            grid-auto-flow: column;
+            @media (min-width: 1024px) {
+                position: relative;
+                max-inline-size: 1024px;
+                padding: 10px 5px 20px 2px;
+            }
+        }
         @media screen and (min-width: 800px) {
+            background: none;
             color: red;
+            left: 10px;
         }
     }
     .test13 {


### PR DESCRIPTION
This pull request implements the necessary algorith changes to the plugin to support [nested at-rules](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting/Nesting_at-rules). 

Previously, the plugin expected that declaration could be contained only in a rule. But with the relatively new [CSS Nesting Module](https://drafts.csswg.org/css-nesting-1/) it is possible to place declarations inside an at-rule. This is what MDM Documentation states:

Any [at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule) whose body contains style rules can be nested inside another style rule using CSS nesting. Style rules nested inside at-rules take their nesting selector definition from the nearest ancestor style rule. Properties can be directly included inside a nested at-rule, acting as if they were nested in a & {...} block.

So, taking this CSS input:

```css
@media (orientation: landscape) {
    .test-ok-1 {
        .test-ok-2 {
            grid-auto-flow: column;
        }
    }
    @media (min-width: 1024px) {
        .test-ok-1 {
            .test-ok-2 {
                position: relative;
                max-inline-size: 1024px;
                padding: 10px 5px 20px 2px;
            }
        }
    }
}

.test-ko-1 {
    .test-ko-2 {
        @media (orientation: landscape) {
            grid-auto-flow: column;
            @media (min-width: 1024px) {
                position: relative;
                max-inline-size: 1024px;
                padding: 10px 5px 20px 2px;
            }
        }
    }
}
```

This was the output before the changes contained in this pull request:

```css
@media (orientation: landscape) {
    .test-ok-1 {
        .test-ok-2 {
            grid-auto-flow: column;
        }
    }

    @media (min-width: 1024px) {
        .test-ok-1 {
            .test-ok-2 {
                position: relative;
                max-inline-size: 1024px;
            }
        }

        [dir="ltr"] .test-ok-1 {
            .test-ok-2 {
                padding: 10px 5px 20px 2px;
            }
        }

        [dir="rtl"] .test-ok-1 {
            .test-ok-2 {
                padding: 10px 2px 20px 5px;
            }
        }
    }
}

.test-ko-1 {
    .test-ko-2 {
        @media (orientation: landscape) {
            grid-auto-flow: column;

            @media (min-width: 1024px) {
                position: relative;
                max-inline-size: 1024px;
                padding: 10px 5px 20px 2px;
            }
        }
    }
}
```

>Note how the first block was processed correctly because all the declarations are placed inside rules, meanwhile the second block was completely ignored because the declarations are placed inside at-rules instead.

After the changes contained in this pull request, this will be the output of the previous input:

```css
@media (orientation: landscape) {
    .test-ok-1 {
        .test-ok-2 {
            grid-auto-flow: column;
        }
    }

    @media (min-width: 1024px) {
        .test-ok-1 {
            .test-ok-2 {
                position: relative;
                max-inline-size: 1024px;
            }
        }

        [dir="ltr"] .test-ok-1 {
            .test-ok-2 {
                padding: 10px 5px 20px 2px;
            }
        }

        [dir="rtl"] .test-ok-1 {
            .test-ok-2 {
                padding: 10px 2px 20px 5px;
            }
        }
    }
}

.test-ko-1 {
    .test-ko-2 {
        @media (orientation: landscape) {
            grid-auto-flow: column;

            @media (min-width: 1024px) {
                position: relative;
                max-inline-size: 1024px;
            }
        }
    }
}

[dir="ltr"] .test-ko-1 {
    .test-ko-2 {
        @media (orientation: landscape) {
            @media (min-width: 1024px) {
                padding: 10px 5px 20px 2px;
            }
        }
    }
}

[dir="rtl"] .test-ko-1 {
    .test-ko-2 {
        @media (orientation: landscape) {
            @media (min-width: 1024px) {
                padding: 10px 2px 20px 5px;
            }
        }
    }
}
```

Closes: #324 