### PR TITLE
Implement a freeze directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [5.6.0] - 2024-12-13
 
 - Add new directives to freeze rules and declarations `/*rtl:freeze*/`, `/*rtl:begin:freeze*/` and `/*rtl:end:freeze*/`
+- Remove references to the legacy package
 
 ## [5.5.1] - 2024-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.6.0] - 2024-12-13
+
+- Add new directives to freeze rules and declarations `/*rtl:freeze*/`, `/*rtl:begin:freeze*/` and `/*rtl:end:freeze*/`
+
 ## [5.5.1] - 2024-11-24
 
 - Small refactor to avoid a circular dependency between two parsers

--- a/README.md
+++ b/README.md
@@ -24,31 +24,19 @@ Install
 #### npm
 
 ```bash
-## Latest version (postcss@^8.0.0)
 npm install postcss-rtlcss --save-dev
-
-## Latest legacy version (postcss@^7.0.0)
-npm install postcss-rtlcss@legacy --save-dev
 ```
 
 #### pnpm
 
 ```bash
-## Latest version (postcss@^8.0.0)
 pnpm add -D postcss-rtlcss
-
-## Latest legacy version (postcss@^7.0.0)
-pnpm add -D postcss-rtlcss@legacy
 ```
 
 #### yarn
 
 ```bash
-## Latest version (postcss@^8.0.0)
 yarn add postcss-rtlcss -D
-
-## Latest legacy version (postcss@^7.0.0)
-yarn add postcss-rtlcss@legacy -D
 ```
 
 Basic usage
@@ -69,11 +57,6 @@ const result = postcss([
 const rtlCSS = result.css;
 ```
 
-##### commonJS with the versions 1.x.x - 2.x.x
-```javascript
-const { postcssRTLCSS, Mode, Source, Autorename } = require('postcss-rtlcss');
-```
-
 #### Usage with ES6 modules
 
 ```javascript
@@ -87,12 +70,6 @@ const result = postcss([
 ]).process(cssInput);
 
 const rtlCSS = result.css;
-```
-
-##### ES6 modules with the versions 1.x.x - 2.x.x
-
-```javascript
-import { postcssRTLCSS, Mode, Source, Autorename } from 'postcss-rtlcss';
 ```
 
 #### Usage in Webpack with postcss-loader
@@ -146,7 +123,7 @@ Examples
 
 #### Output using the combined mode (default and recommended)
 
-This is the recommended method, it will generate more CSS code but each direction will have their specific CSS declarations and there is no need of overriding properties.
+This is the recommended method, it will generate more CSS code because each direction will have their specific prefixed rules but it is the safest option.
 
 ```css
 .test1, .test2 {
@@ -188,7 +165,7 @@ This is the recommended method, it will generate more CSS code but each directio
 #### Output using the override mode
 
 >[!IMPORTANT]
->This method is not recommended, check below why
+>This method is not recommended, [check below why](#disadvantages-of-the-two-methods-to-override)
 
 This is one of the alternative methods to override. It will generate less code because it lets the main rule intact most of the time and generates shorter specific rules to override the properties that are affected by the direction of the text.
 
@@ -227,7 +204,7 @@ This is one of the alternative methods to override. It will generate less code b
 #### Output using the diff mode
 
 >[!IMPORTANT]
->This method is not recommended, check below why
+>This method is not recommended, [check below why](#disadvantages-of-the-two-methods-to-override)
 
 This is the second alternative method to override. It generates the minimum amount of code because it only outputs the rules that have been flipped and without prefixing them. The intention of this method is to generate a separate stylesheet file that will be loaded on top of the original one to override those rules that need to be flipped in certain direction.
 
@@ -245,13 +222,7 @@ This is the second alternative method to override. It generates the minimum amou
 }
 ```
 
->[!IMPORTANT]
->But the two methods to override have disadvantages:
-
-<details><summary>Disadvantages of the override methods</summary>
-<p>
-
-The methods to override are discouraged because:
+#### Disadvantages of the two methods to override
 
 1. Some directives as `/*rtl:freeze*/`, `/*rtl:begin:freeze*/` and `/*rtl:end:freeze*/` do not work with these methods
 2. They can override a property that is coming from another class if multiple classes are used at the same time. Take a look at the next `HTML` and `CSS` codes:
@@ -366,10 +337,7 @@ And using the `diff` method the generated code will be:
 }
 ```
 
-</p>
-</details>
-
-Options
+Plugin Options
 ---
 
 All the options are optional, and a default value will be used if any of them is omitted or the type or format of them is wrong
@@ -380,19 +348,19 @@ All the options are optional, and a default value will be used if any of them is
 | [ltrPrefix](#ltrprefix-and-rtlprefix)                   | `string` or `string[]`    | `[dir="ltr"]`   | Prefix to use in the left-to-right CSS rules                 |
 | [rtlPrefix](#ltrprefix-and-rtlprefix)                   | `string` or `string[]`    | `[dir="rtl"]`   | Prefix to use in the right-to-left CSS rules                 |
 | [bothPrefix](#bothprefix)                               | `string` or `string[]`    | `[dir]`         | Prefix to create a new rule that affects both directions when the specificity of the ltr or rtl rules will override its declarations |
-| [prefixSelectorTransformer](#prefixselectortransformer) | `function` | `null` | Transform function to have more control over the selectors prefixing logic |
+| [prefixSelectorTransformer](#prefixselectortransformer) | `function`                | `null`          | Transform function to have more control over the selectors prefixing logic |
 | [safeBothPrefix](#safebothprefix)                       | `boolean`                 | `false`         | Add the `bothPrefix` to those declarations that can be affected by the direction to avoid them being overridden by specificity |
-| [ignorePrefixedRules](#ignoreprefixedrules)             | `boolean`                 | true            | Ignores rules that have been prefixed with some of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix` |
+| [ignorePrefixedRules](#ignoreprefixedrules)             | `boolean`                 | `true`          | Ignores rules that have been prefixed with some of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix` |
 | [source](#source)                                       | `Source (string)`         | `Source.ltr`    | The direction from which the final CSS will be generated     |
-| [processUrls](#processurls)                             | `boolean`                 | `false`         | Change the strings in URLs using the string map         |
+| [processUrls](#processurls)                             | `boolean`                 | `false`         | Change the strings in URLs using the string map              |
 | [processRuleNames](#processrulenames)                   | `boolean`                 | `false`         | Swap two rules containing no directional properties if they match any entry in `stringMap` when the direction changes |
 | [processKeyFrames](#processkeyframes)                   | `boolean`                 | `false`         | Flip keyframe animations                                     |
 | [processEnv](#processenv)                               | `boolean`                 | `true`          | When processEnv is false, it prevents flipping agent-defined environment variables (`safe-area-inset-left` and `safe-area-inset-right`) |
 | [useCalc](#usecalc)                                     | `boolean`                 | `false`         | Flips `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) |
-| [stringMap](#stringmap)                                 | `PluginStringMap[]`       | Check below     | An array of strings maps that will be used to make the replacements of the declarations' URLs and to match the names of the rules if `processRuleNames` is `true` |
+| [stringMap](#stringmap)                                 | `PluginStringMap[]`       | [Check below](#stringmap) | An array of strings maps that will be used to make the replacements of the declarations' URLs and to match the names of the rules if `processRuleNames` is `true` |
 | [greedy](#greedy)                                       | `boolean`                 | `false`         | When greedy is `true`, the matches of `stringMap` will not take into account word boundaries |
-| [aliases](#aliases)                                     | `Record<string, string>`  | `{}`            | A strings map to treat some declarations as others |
-| [processDeclarationPlugins](#processdeclarationplugins) | `DeclarationPlugin[]` | `[]`         | Plugins applied when processing CSS declarations |
+| [aliases](#aliases)                                     | `Record<string, string>`  | `{}`            | A strings map to treat some declarations as others           |
+| [processDeclarationPlugins](#processdeclarationplugins) | `DeclarationPlugin[]`     | `[]`            | Plugins applied when processing CSS declarations             |
 
 ---
 
@@ -571,7 +539,7 @@ This function will be used to transform the selectors and prefixing them at our 
 
 >[!NOTE]
 >* If the function doesn‘t return a string, the default prefixing logic will be used.
->* If this function is used, be aware that rules using `html`, `:root` or `:::view-transition` will follow the custom prefixing logic. You should cover these cases.
+>* If this function is used, be aware that rules using `html`, `:root` or `::view-transition` will follow the custom prefixing logic. You should cover these cases.
 
 ##### input
 
@@ -1298,9 +1266,6 @@ const options = {
 
 This property consists of a string map to treat some declarations as others, very useful to flip the values of [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 
->[!NOTE]
->This property is not available in the legacy version of the package
-
 ##### input
 
 ```css
@@ -1412,24 +1377,24 @@ Control directives are placed between rules or declarations. They can target a s
 >[!IMPORTANT]
 >Block directives (the ones that start with `begin` and end with `end`) should be placed outside rules to apply the directive to multiple rules or inside a rule to apply the directive to multiple declarations. You should not place the begin of a directive outside a rule and the end inside one (or vice versa) or you will get undesired results.
 
-| Directive                                                  | Description                                                                                                                                    |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| [/\*rtl:ignore\*/](#rtlignore)                             | Ignores processing of the following rule or declaration                                                           |
-| [/\*rtl:begin:ignore\*/](#rtlbeginignore-and-rtlendignore) | Starts an ignoring block                                                                                          |
-| [/\*rtl:end:ignore\*/](#rtlbeginignore-and-rtlendignore)   | Ends an ignoring block                                                                                            |
-| [/\*rtl:freeze\*/](#rtlfreeze)         | Freezes the rule or declaration in the current direction but does nothing with the counterpart direction if there are flippable declarations     |
-| [/\*rtl:begin:freeze\*/](#rtlbeginfreeze-and-rtlendfreeze) | Starts a freeze block                                                                                             |
-| [/\*rtl:end:freeze\*/](#rtlbeginfreeze-and-rtlendfreeze)   | Ends a freeze block                                                                                               |
-| [/\*rtl:urls\*/](#rtlurls)           | This directive set the `processUrls` option to `true` in the next declaration or in the declarations of the next rule no mattering the value of the global `processUrls` option  |
-| [/\*rtl:begin:urls\*/](#rtlbeginrules-and-rtlendrules)     | Starts a `processUrls` block block                                                                                |
-| [/\*rtl:end:urls\*/](#rtlbeginrules-and-rtlendrules)       | Ends a `processUrls` block block                                                                                  |
-| [/\*rtl:rules\*/](#rtlrules)          | This directive set the `processRuleNames` option to `true` in the next rule no mattering the value of the global `processRuleNames` option  |
-| [/\*rtl:begin:rules\*/](#rtlbeginrules-and-rtlendrules)    | Starts a `processRuleNames` block block |
-| [/\*rtl:end:rules\*/](#rtlbeginrules-and-rtlendrules)      | Ends a `processRuleNames` block block   | 
-| [/\*rtl:source:{source}\*/](#rtlsourcesource)| Set the source of a rule or a declaration no mattering the value of the `source` property                         |
-| [/\*rtl:begin:source:{source}\*/](#rtlbeginsourcesource-and-rtlendsource) | Starts a source block                                                                                      |
-| [/\*rtl:end:source\*/](#rtlbeginsourcesource-and-rtlendsource)     | Ends a source block                                                                                               |
-| [/\*rtl:raw:{CSS}\*/](#rtlrawcss)      | Parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed `CSS` will be treated as `rtl` or `ltr` |
+| Directive                                                      | Description                                             |
+| -------------------------------------------------------------- | ------------------------------------------------------- |
+| [/\*rtl:ignore\*/](#rtlignore)                                 | Ignores processing of the following rule or declaration |
+| [/\*rtl:begin:ignore\*/](#rtlbeginignore-and-rtlendignore)     | Starts an ignoring block                                |
+| [/\*rtl:end:ignore\*/](#rtlbeginignore-and-rtlendignore)       | Ends an ignoring block                                  |
+| [/\*rtl:freeze\*/](#rtlfreeze)                                 | Freezes the rule or declaration in the current direction but does nothing with the counterpart direction if there are flippable declarations |
+| [/\*rtl:begin:freeze\*/](#rtlbeginfreeze-and-rtlendfreeze)     | Starts a freeze block                                   |
+| [/\*rtl:end:freeze\*/](#rtlbeginfreeze-and-rtlendfreeze)       | Ends a freeze block                                     |
+| [/\*rtl:urls\*/](#rtlurls)                                     | This directive set the `processUrls` option to `true` in the next declaration or in the declarations of the next rule no mattering the value of the global `processUrls` option |
+| [/\*rtl:begin:urls\*/](#rtlbeginrules-and-rtlendrules)         | Starts a `processUrls` block block                      |
+| [/\*rtl:end:urls\*/](#rtlbeginrules-and-rtlendrules)           | Ends a `processUrls` block block                        |
+| [/\*rtl:rules\*/](#rtlrules)                                   | This directive set the `processRuleNames` option to `true` in the next rule no mattering the value of the global `processRuleNames` option |
+| [/\*rtl:begin:rules\*/](#rtlbeginrules-and-rtlendrules)        | Starts a `processRuleNames` block block                 |
+| [/\*rtl:end:rules\*/](#rtlbeginrules-and-rtlendrules)          | Ends a `processRuleNames` block block                   | 
+| [/\*rtl:source:{source}\*/](#rtlsourcesource)                  | Set the source of a rule or a declaration no mattering the value of the `source` property |
+| [/\*rtl:begin:source:{source}\*/](#rtlbeginsourcesource-and-rtlendsource) | Starts a source block                        |
+| [/\*rtl:end:source\*/](#rtlbeginsourcesource-and-rtlendsource) | Ends a source block                                     |
+| [/\*rtl:raw:{CSS}\*/](#rtlrawcss)                              | Parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed `CSS` will be treated as `rtl` or `ltr` |
 
 ---
 
@@ -1562,13 +1527,9 @@ Ignoring multiple declarations:
 ## /\*rtl:freeze\*/
 
 >[!IMPORTANT]
->1. This directive only works in `combined` mode. If you use it in `override` or `diff` mode it will be ignored.
->2. If you use this directive with declarations that are not affected by page direction, it is recommended that you set the [safeBothPrefix](#safebothprefix) option in `true`.
+>This directive only works in `combined` mode. If you use it in `override` or `diff` modes it will be ignored.
 
->[!NOTE]
->This directive is not available in the legacy version of tha package
-
-This directive freezes the rule or declaration in the current direction but does nothing with the counterpart direction if there are flippable declarations. When used with a rule, it will freeze it in the current direction even if it is doesn't contain flippable declarations. When it is used in a declration, it will freeze the declaration in the current direction even if it is not flippable.
+This directive freezes the rule or declaration in the current direction but does nothing with the counterpart direction. When used with a rule, it will freeze it in the current direction even if it is doesn't contain flippable declarations. When it is used in a declration, it will freeze the declaration in the current direction even if it is not flippable.
 
 ##### input
 
@@ -1614,13 +1575,9 @@ This directive freezes the rule or declaration in the current direction but does
 ## /\*rtl:begin:freeze\*/ and /\*rtl:end:freeze\*/
 
 >[!IMPORTANT]
->1. This directive only works in `combined` mode. If you use it in `override` or `diff` mode it will be ignored.
->2. If you use these directives with declarations that are not affected by page direction, it is recommended that you set the [safeBothPrefix](#safebothprefix) option in `true`.
+>This directive only works in `combined` mode. If you use it in `override` or `diff` modes it will be ignored.
 
->[!NOTE]
->These directives are not available in the legacy version of tha package
-
-These directives should be used together, they will provide the beginning and the end for freezing rules or declarations. The rules or delclarations between these blocks, will be frozen in the current direction even if there are no flippable declarations involved.
+These directives should be used together, they will provide the beginning and the end for freezing rules or declarations. The rules or declarations between these blocks, will be frozen in the current direction even if there are no flippable declarations involved.
 
 Freezing multiple rules:
 
@@ -2046,13 +2003,13 @@ Value Directives
 
 Value directives are placed anywhere inside the declaration value. They target the containing declaration node.
 
-| Directive                | Description                                                                      |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| [/\*rtl:ignore\*/](#rtlignore-1)         | Ignores processing of the declaration                                            |
-| [/\*rtl:append{value}\*/](#rtlappendvalue)  | Appends `{value}` to the end of the declaration value                            |
-| [/\*rtl:insert:{value}\*/](#rtlinsertvalue) | Inserts `{value}` to where the directive is located inside the declaration value |
-| [/\*rtl:prepend:{value}\*/](#rtlprependvalue)| Prepends `{value}` to the begining of the declaration value                      |
-| [/\*rtl:{value}\*/](#rtlvalue)        | Replaces the declaration value with `{value}`                                    |
+| Directive                                     | Description                                                                      |
+| --------------------------------------------- | -------------------------------------------------------------------------------- |
+| [/\*rtl:ignore\*/](#rtlignore-1)              | Ignores processing of the declaration                                            |
+| [/\*rtl:append{value}\*/](#rtlappendvalue)    | Appends `{value}` to the end of the declaration value                            |
+| [/\*rtl:insert:{value}\*/](#rtlinsertvalue)   | Inserts `{value}` to where the directive is located inside the declaration value |
+| [/\*rtl:prepend:{value}\*/](#rtlprependvalue) | Prepends `{value}` to the begining of the declaration value                      |
+| [/\*rtl:{value}\*/](#rtlvalue)                | Replaces the declaration value with `{value}`                                    |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -374,32 +374,29 @@ Options
 
 All the options are optional, and a default value will be used if any of them is omitted or the type or format of them is wrong
 
-| Option             | Type                      | Default         | Description                                                  |
-| ------------------ | ------------------------- | --------------- | ------------------------------------------------------------ |
-| mode               | `Mode (string)`           | `Mode.combined` | Mode of generating the final CSS rules                       |
-| ltrPrefix          | `string` or `string[]`    | `[dir="ltr"]`   | Prefix to use in the left-to-right CSS rules                 |
-| rtlPrefix          | `string` or `string[]`    | `[dir="rtl"]`   | Prefix to use in the right-to-left CSS rules                 |
-| bothPrefix         | `string` or `string[]`    | `[dir]`         | Prefix to create a new rule that affects both directions when the specificity of the ltr or rtl rules will override its declarations |
-| prefixSelectorTransformer | `function` | `null` | Transform function to have more control over the selectors prefixing logic |
-| safeBothPrefix     | `boolean`                 | `false`         | Add the `bothPrefix` to those declarations that can be affected by the direction to avoid them being overridden by specificity |
-| ignorePrefixedRules| `boolean`                 | true            | Ignores rules that have been prefixed with some of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix` |
-| source             | `Source (string)`         | `Source.ltr`    | The direction from which the final CSS will be generated     |
-| processUrls        | `boolean`                 | `false`         | Change the strings in URLs using the string map         |
-| processRuleNames   | `boolean`                 | `false`         | Swap two rules containing no directional properties if they match any entry in `stringMap` when the direction changes |
-| processKeyFrames   | `boolean`                 | `false`         | Flip keyframe animations                                     |
-| processEnv         | `boolean`                 | `true`          | When processEnv is false, it prevents flipping agent-defined environment variables (`safe-area-inset-left` and `safe-area-inset-right`) |
-| useCalc            | `boolean`                 | `false`         | Flips `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) |
-| stringMap          | `PluginStringMap[]`       | Check below     | An array of strings maps that will be used to make the replacements of the declarations' URLs and to match the names of the rules if `processRuleNames` is `true` |
-| greedy             | `boolean`                 | `false`         | When greedy is `true`, the matches of `stringMap` will not take into account word boundaries |
-| aliases            | `Record<string, string>`  | `{}`            | A strings map to treat some declarations as others |
-| processDeclarationPlugins | `DeclarationPlugin[]` | `[]`         | Plugins applied when processing CSS declarations |
+| Option                                                  | Type                      | Default         | Description                                                  |
+| ------------------------------------------------------- | ------------------------- | --------------- | ------------------------------------------------------------ |
+| [mode](#mode)                                           | `Mode (string)`           | `Mode.combined` | Mode of generating the final CSS rules                       |
+| [ltrPrefix](#ltrprefix-and-rtlprefix)                   | `string` or `string[]`    | `[dir="ltr"]`   | Prefix to use in the left-to-right CSS rules                 |
+| [rtlPrefix](#ltrprefix-and-rtlprefix)                   | `string` or `string[]`    | `[dir="rtl"]`   | Prefix to use in the right-to-left CSS rules                 |
+| [bothPrefix](#bothprefix)                               | `string` or `string[]`    | `[dir]`         | Prefix to create a new rule that affects both directions when the specificity of the ltr or rtl rules will override its declarations |
+| [prefixSelectorTransformer](#prefixselectortransformer) | `function` | `null` | Transform function to have more control over the selectors prefixing logic |
+| [safeBothPrefix](#safebothprefix)                       | `boolean`                 | `false`         | Add the `bothPrefix` to those declarations that can be affected by the direction to avoid them being overridden by specificity |
+| [ignorePrefixedRules](#ignoreprefixedrules)             | `boolean`                 | true            | Ignores rules that have been prefixed with some of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix` |
+| [source](#source)                                       | `Source (string)`         | `Source.ltr`    | The direction from which the final CSS will be generated     |
+| [processUrls](#processurls)                             | `boolean`                 | `false`         | Change the strings in URLs using the string map         |
+| [processRuleNames](#processrulenames)                   | `boolean`                 | `false`         | Swap two rules containing no directional properties if they match any entry in `stringMap` when the direction changes |
+| [processKeyFrames](#processkeyframes)                   | `boolean`                 | `false`         | Flip keyframe animations                                     |
+| [processEnv](#processenv)                               | `boolean`                 | `true`          | When processEnv is false, it prevents flipping agent-defined environment variables (`safe-area-inset-left` and `safe-area-inset-right`) |
+| [useCalc](#usecalc)                                     | `boolean`                 | `false`         | Flips `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) |
+| [stringMap](#stringmap)                                 | `PluginStringMap[]`       | Check below     | An array of strings maps that will be used to make the replacements of the declarations' URLs and to match the names of the rules if `processRuleNames` is `true` |
+| [greedy](#greedy)                                       | `boolean`                 | `false`         | When greedy is `true`, the matches of `stringMap` will not take into account word boundaries |
+| [aliases](#aliases)                                     | `Record<string, string>`  | `{}`            | A strings map to treat some declarations as others |
+| [processDeclarationPlugins](#processdeclarationplugins) | `DeclarationPlugin[]` | `[]`         | Plugins applied when processing CSS declarations |
 
 ---
 
-#### mode
-
-<details><summary>Expand</summary>
-<p>
+## mode
 
 The mode option has been explained in the [Output using the combined mode](#output-using-the-combined-mode-default), the [Output using the override mode](#output-using-the-override-mode), and the [Output using the diff mode](#output-using-the-diff-mode) sections. To avoid using magic strings, the package exposes an object with these values, but it is possible to use strings values anyway:
 
@@ -426,16 +423,9 @@ const outputDiff = postcss([
 ]).process(input);
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### ltrPrefix and rtlPrefix
-
-<details><summary>Expand</summary>
-<p>
+## ltrPrefix and rtlPrefix
 
 These two options manage the prefix strings for each direction. They can be strings or arrays of strings:
 
@@ -518,16 +508,9 @@ const options = {
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### bothPrefix
-
-<details><summary>Expand</summary>
-<p>
+## bothPrefix
 
 This prefix will be used in some specific cases in which a ltr or rtl rule will override declarations located in the main rule due to [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity). Consider the next example using the option `processUrls` as `true`:
 
@@ -580,20 +563,13 @@ To solve this, another rule will be created at the end using the `bothPrefix` pa
 
 And no matter the direction, the `background-size` property is respected.
 
-</p>
-
-</details>
-
 ---
 
-#### prefixSelectorTransformer
-
-<details><summary>Expand</summary>
-<p>
+## prefixSelectorTransformer
 
 This function will be used to transform the selectors and prefixing them at our will. The first parameter will be the prefix that will be used and the second the current selector:
 
->Notes:
+>[!NOTE]
 >* If the function doesn‘t return a string, the default prefixing logic will be used.
 >* If this function is used, be aware that rules using `html`, `:root` or `:::view-transition` will follow the custom prefixing logic. You should cover these cases.
 
@@ -658,16 +634,9 @@ const options = {
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### safeBothPrefix
-
-<details><summary>Expand</summary>
-<p>
+## safeBothPrefix
 
 This option will add the `boxPrefix` option to those declarations that can be flipped, no matter if they are not overridden in the same rule. This avoids them being overridden by [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) of other flipped declarations contained in other rules. For example, let's consider that we have a `div` element with the next rules:
 
@@ -733,16 +702,9 @@ The result is that the `padding` properties of `test1` have more specificity tha
 
 As `test2` has the same level of specificity as `test1`, now the result is that the `padding` is reset if both rules are used at the same time.
 
-</p>
-
-</details>
-
 ---
 
-#### ignorePrefixedRules
-
-<details><summary>Expand</summary>
-<p>
+## ignorePrefixedRules
 
 This option is to ignore the rules that have been prefixed with one of the prefixes contained in `ltrPrefix`, `rtlPrefix`, or `bothPrefix`:
 
@@ -802,16 +764,9 @@ const options = { ignorePrefixedRules: false };
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### source
-
-<details><summary>Expand</summary>
-<p>
+## source
 
 This option manages if the conversion will be from `LTR` to `RTL` or vice versa.
 
@@ -870,16 +825,9 @@ const options = {
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### processUrls
-
-<details><summary>Expand</summary>
-<p>
+## processUrls
 
 This options manages if the strings of the URLs should be flipped taken into account the string map:
 
@@ -934,20 +882,14 @@ const options = { processUrls: true };
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### processRuleNames
-
-<details><summary>Expand</summary>
-<p>
+## processRuleNames
 
 If it is `true`, it swaps two rules containing no directional properties if they match any entry in `stringMap` when the direction changes
 
->Note that this option will not prefix those rules that have been processed already because they had directional properties.
+>[!IMPORTANT]
+>This option will not prefix those rules that have been processed already because they had directional properties.
 
 ##### input
 
@@ -998,16 +940,9 @@ const options = {
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### processKeyFrames
-
-<details><summary>Expand</summary>
-<p>
+## processKeyFrames
 
 This option manages if the @keyframes animation rules should be flipped:
 
@@ -1093,16 +1028,9 @@ const options = { processKeyFrames: true };
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### processEnv
-
-<details><summary>Expand</summary>
-<p>
+## processEnv
 
 This options manages if the agent-defined environment variables should be flipped:
 
@@ -1198,16 +1126,9 @@ const options = { processEnv: false };
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### useCalc
-
-<details><summary>Expand</summary>
-<p>
+## useCalc
 
 When this option is enabled, it flips `background-position-x` and `transform-origin` properties if they are expressed in length units using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc):
 
@@ -1275,16 +1196,9 @@ const options = { useCalc: true };
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### stringMap
-
-<details><summary>Expand</summary>
-<p>
+## stringMap
 
 An array of strings maps that will be used to make the replacements of the declarations' URLs and to match rules selectors names if the `processRuleNames` option is `true`. The name parameter is optional, but if you want to override any of the default string maps, just add your own using the same name.
 
@@ -1306,16 +1220,9 @@ const options = {
 };
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### greedy
-
-<details><summary>Expand</summary>
-<p>
+## greedy
 
 When `greedy` is `true`, the matches of the `stringMap` will not take into account word boundaries.
 
@@ -1385,20 +1292,14 @@ const options = {
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### aliases
-
-<details><summary>Expand</summary>
-<p>
+## aliases
 
 This property consists of a string map to treat some declarations as others, very useful to flip the values of [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 
->Note: This property is not available in the legacy version of the package
+>[!NOTE]
+>This property is not available in the legacy version of the package
 
 ##### input
 
@@ -1452,16 +1353,9 @@ const options = {
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### processDeclarationPlugins
-
-<details><summary>Expand</summary>
-<p>
+## processDeclarationPlugins
 
 The intention of the processDeclarationPlugins option is to process the declarations to extend or override RTLCSS functionality. For example, we can avoid automatically flipping of `background-potion`.
 
@@ -1508,10 +1402,6 @@ const options = {
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
 Control Directives
@@ -1519,33 +1409,31 @@ Control Directives
 
 Control directives are placed between rules or declarations. They can target a single node or a set of nodes.
 
->Note: block directives (the ones that start with `begin` and end with `end`) should be placed outside rules to apply the directive to multiple rules or inside a rule to apply the directive to multiple declarations. You should not place the begin of a directive outside a rule and the end inside one (or vice versa) or you will get undesired results.
+>[!IMPORTANT]
+>Block directives (the ones that start with `begin` and end with `end`) should be placed outside rules to apply the directive to multiple rules or inside a rule to apply the directive to multiple declarations. You should not place the begin of a directive outside a rule and the end inside one (or vice versa) or you will get undesired results.
 
-| Directive                | Description                                                                                                                                    |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/*rtl:ignore*/`         | Ignores processing of the following rule or declaration                                                           |
-| `/*rtl:begin:ignore*/`   | Starts an ignoring block                                                                                          |
-| `/*rtl:end:ignore*/`     | Ends an ignoring block                                                                                            |
-| `/*rtl:freeze*/`         | Freezes the rule or declaration in the current direction but does nothing with the counterpart direction if there are flippable declarations     |
-| `/*rtl:begin:freeze*/`   | Starts a freeze block                                                                                             |
-| `/*rtl:end:freeze*/`     | Ends a freeze block                                                                                               |
-| `/*rtl:urls*/`           | This directive set the `processUrls` option to `true` in the next declaration or in the declarations of the next rule no mattering the value of the global `processUrls` option  |
-| `/*rtl:begin:urls*/`     | Starts a `processUrls` block block                                                                                |
-| `/*rtl:end:urls*/`       | Ends a `processUrls` block block                                                                                  |
-| `/*rtl:rules*/`          | This directive set the `processRuleNames` option to `true` in the next rule no mattering the value of the global `processRuleNames` option  |
-| `/*rtl:begin:rules*/`    | Starts a `processRuleNames` block block |
-| `/*rtl:end:rules*/`      | Ends a `processRuleNames` block block   | 
-| `/*rtl:source:{source}*/`| Set the source of a rule or a declaration no mattering the value of the `source` property                         |
-| `/*rtl:begin:source:{source}*/` | Starts a source block                                                                                      |
-| `/*rtl:end:source*/`     | Ends a source block                                                                                               |
-| `/*rtl:raw:{CSS}*/`      | Parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed `CSS` will be treated as `rtl` or `ltr` |
+| Directive                                                  | Description                                                                                                                                    |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| [/\*rtl:ignore\*/](#rtlignore)                             | Ignores processing of the following rule or declaration                                                           |
+| [/\*rtl:begin:ignore\*/](#rtlbeginignore-and-rtlendignore) | Starts an ignoring block                                                                                          |
+| [/\*rtl:end:ignore\*/](#rtlbeginignore-and-rtlendignore)   | Ends an ignoring block                                                                                            |
+| [/\*rtl:freeze\*/](#rtlfreeze)         | Freezes the rule or declaration in the current direction but does nothing with the counterpart direction if there are flippable declarations     |
+| [/\*rtl:begin:freeze\*/](#rtlbeginfreeze-and-rtlendfreeze) | Starts a freeze block                                                                                             |
+| [/\*rtl:end:freeze\*/](#rtlbeginfreeze-and-rtlendfreeze)   | Ends a freeze block                                                                                               |
+| [/\*rtl:urls\*/](#rtlurls)           | This directive set the `processUrls` option to `true` in the next declaration or in the declarations of the next rule no mattering the value of the global `processUrls` option  |
+| [/\*rtl:begin:urls\*/](#rtlbeginrules-and-rtlendrules)     | Starts a `processUrls` block block                                                                                |
+| [/\*rtl:end:urls\*/](#rtlbeginrules-and-rtlendrules)       | Ends a `processUrls` block block                                                                                  |
+| [/\*rtl:rules\*/](#rtlrules)          | This directive set the `processRuleNames` option to `true` in the next rule no mattering the value of the global `processRuleNames` option  |
+| [/\*rtl:begin:rules\*/](#rtlbeginrules-and-rtlendrules)    | Starts a `processRuleNames` block block |
+| [/\*rtl:end:rules\*/](#rtlbeginrules-and-rtlendrules)      | Ends a `processRuleNames` block block   | 
+| [/\*rtl:source:{source}\*/](#rtlsourcesource)| Set the source of a rule or a declaration no mattering the value of the `source` property                         |
+| [/\*rtl:begin:source:{source}\*/](#rtlbeginsourcesource-and-rtlendsource) | Starts a source block                                                                                      |
+| [/\*rtl:end:source\*/](#rtlbeginsourcesource-and-rtlendsource)     | Ends a source block                                                                                               |
+| [/\*rtl:raw:{CSS}\*/](#rtlrawcss)      | Parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed `CSS` will be treated as `rtl` or `ltr` |
 
 ---
 
-#### `/*rtl:ignore*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:ignore\*/
 
 This directive ignores processing of the following rule or declaration. In the next block the whole declaration will be ignored.
 
@@ -1596,20 +1484,14 @@ In the next block only the `left` property will be ignored:
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:begin:ignore*/` and `/*rtl:end:ignore*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:begin:ignore\*/ and /\*rtl:end:ignore\*/
 
 These directives should be used together, they will provide the beginning and the end for ignoring rules or declarations.
 
->**Note:** The directives inserted between these blocks will be ignored and maintained in the final output.
+>[!NOTE]
+>The directives inserted between these blocks will be ignored and maintained in the final output.
 
 Ignoring multiple rules:
 
@@ -1675,20 +1557,16 @@ Ignoring multiple declarations:
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:freeze*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:freeze\*/
 
 >[!IMPORTANT]
 >1. This directive only works in `combined` mode. If you use it in `override` or `diff` mode it will be ignored.
 >2. If you use this directive with declarations that are not affected by page direction, it is recommended that you set the [safeBothPrefix](#safebothprefix) option in `true`.
+
+>[!NOTE]
+>This directive is not available in the legacy version of tha package
 
 This directive freezes the rule or declaration in the current direction but does nothing with the counterpart direction if there are flippable declarations. When used with a rule, it will freeze it in the current direction even if it is doesn't contain flippable declarations. When it is used in a declration, it will freeze the declaration in the current direction even if it is not flippable.
 
@@ -1731,20 +1609,16 @@ This directive freezes the rule or declaration in the current direction but does
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:begin:freeze*/` and `/*rtl:end:freeze*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:begin:freeze\*/ and /\*rtl:end:freeze\*/
 
 >[!IMPORTANT]
 >1. This directive only works in `combined` mode. If you use it in `override` or `diff` mode it will be ignored.
 >2. If you use these directives with declarations that are not affected by page direction, it is recommended that you set the [safeBothPrefix](#safebothprefix) option in `true`.
+
+>[!NOTE]
+>These directives are not available in the legacy version of tha package
 
 These directives should be used together, they will provide the beginning and the end for freezing rules or declarations. The rules or delclarations between these blocks, will be frozen in the current direction even if there are no flippable declarations involved.
 
@@ -1816,16 +1690,9 @@ Freezing multiple declarations:
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:urls*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:urls\*/
 
 This directive set the `processUrls` option to `true` in the next declaration or in the declarations of the next rule no mattering the value of the global `processUrls` option:
 
@@ -1863,16 +1730,9 @@ This directive set the `processUrls` option to `true` in the next declaration or
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:begin:urls*/` and `/*rtl:end:urls*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:begin:urls\*/ and /\*rtl:end:urls\*/
 
 These directives should be used together, they will provide the beginning and the end for `processUrls` blocks.
 
@@ -1927,16 +1787,9 @@ These directives should be used together, they will provide the beginning and th
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:rules*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:rules\*/
 
 This directive set the `processRuleNames` option to `true` in the next rule no mattering the value of the global `processRuleNames` option:
 
@@ -1992,16 +1845,9 @@ This directive set the `processRuleNames` option to `true` in the next rule no m
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:begin:rules*/` and `/*rtl:end:rules*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:begin:rules\*/ and /\*rtl:end:rules\*/
 
 These directives should be used together, they will provide the beginning and the end for `processRuleNames` blocks.
 
@@ -2055,16 +1901,9 @@ These directives should be used together, they will provide the beginning and th
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:source:{source}*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:source:{source}\*/
 
 This directive sets the source of a rule or a directive ignoring the value of the `source` property:
 
@@ -2102,16 +1941,9 @@ This directive sets the source of a rule or a directive ignoring the value of th
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:begin:source:{source}*/` and `/*rtl:end:source*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:begin:source:{source}\*/ and /\*rtl:end:{source}\*/
 
 These directives should be used together, they will provide the beginning and the end of source blocks for rules or declarations:
 
@@ -2150,16 +1982,9 @@ These directives should be used together, they will provide the beginning and th
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:raw:{CSS}*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:raw:{CSS}\*/
 
 Parses the `CSS` parameter and inserts it in its place. Depending on the `source` parameter the parsed CSS will be treated as `rtl` or `ltr`:
 
@@ -2214,10 +2039,6 @@ Parses the `CSS` parameter and inserts it in its place. Depending on the `source
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
 Value Directives
@@ -2227,18 +2048,15 @@ Value directives are placed anywhere inside the declaration value. They target t
 
 | Directive                | Description                                                                      |
 | ------------------------ | -------------------------------------------------------------------------------- |
-| `/*rtl:ignore*/`         | Ignores processing of the declaration                                            |
-| `/*rtl:append{value}*/`  | Appends `{value}` to the end of the declaration value                            |
-| `/*rtl:insert:{value}*/` | Inserts `{value}` to where the directive is located inside the declaration value |
-| `/*rtl:prepend:{value}*/`| Prepends `{value}` to the begining of the declaration value                      |
-| `/*rtl:{value}*/`        | Replaces the declaration value with `{value}`                                    |
+| [/\*rtl:ignore\*/](#rtlignore-1)         | Ignores processing of the declaration                                            |
+| [/\*rtl:append{value}\*/](#rtlappendvalue)  | Appends `{value}` to the end of the declaration value                            |
+| [/\*rtl:insert:{value}\*/](#rtlinsertvalue) | Inserts `{value}` to where the directive is located inside the declaration value |
+| [/\*rtl:prepend:{value}\*/](#rtlprependvalue)| Prepends `{value}` to the begining of the declaration value                      |
+| [/\*rtl:{value}\*/](#rtlvalue)        | Replaces the declaration value with `{value}`                                    |
 
 ---
 
-#### `/*rtl:ignore*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:ignore\*/
 
 This directive ignores processing of the current declaration:
 
@@ -2267,16 +2085,9 @@ This directive ignores processing of the current declaration:
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:append{value}*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:append{value}\*/
 
 This directive appends `{value}` to the end of the declaration value:
 
@@ -2303,16 +2114,9 @@ This directive appends `{value}` to the end of the declaration value:
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:insert:{value}*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:insert:{value}\*/
 
 This directive inserts `{value}` to where the directive is located inside the declaration value:
 
@@ -2339,16 +2143,9 @@ This directive inserts `{value}` to where the directive is located inside the de
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:prepend:{value}*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:prepend:{value}\*/
 
 This directive prepends `{value}` to the begining of the declaration value:
 
@@ -2375,16 +2172,9 @@ This directive prepends `{value}` to the begining of the declaration value:
 }
 ```
 
-</p>
-
-</details>
-
 ---
 
-#### `/*rtl:{value}*/`
-
-<details><summary>Expand</summary>
-<p>
+## /\*rtl:{value}\*/
 
 This directive replaces the declaration value with `{value}`:
 
@@ -2410,10 +2200,6 @@ This directive replaces the declaration value with `{value}`:
     right: 10px;
 }
 ```
-
-</p>
-
-</details>
 
 ---
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -152,6 +152,7 @@ export type RuleParser = (
     parsers: Parsers,
     container: Container,
     parentSourceDirective?: string,
+    parentFreezeDirectiveActive?: boolean,
     hasParentRule?: boolean
 ) => void;
 
@@ -159,6 +160,7 @@ export type AtRuleParser = (
     parsers: Parsers,
     container: Container,
     parentSourceDirective?: string,
+    parentFreezeDirectiveActive?: boolean,
     hasParentRule?: boolean
 ) => void;
 
@@ -170,6 +172,7 @@ export type DeclarationParser = (
     container: DeclarationContainer,
     hasParentRule: boolean,
     ruleSourceDirectiveValue: string,
+    parentFreezeDirectiveActive: boolean,
     processRule: boolean,
     rename: boolean
 ) => void;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -27,6 +27,7 @@ export enum TYPEOF {
 
 export enum CONTROL_DIRECTIVE {
     IGNORE = 'ignore',
+    FREEZE = 'freeze',
     URLS = 'urls',
     RULES = 'rules',
     SOURCE = 'source',

--- a/src/parsers/atrules.ts
+++ b/src/parsers/atrules.ts
@@ -22,6 +22,7 @@ export const parseAtRules = (
     parsers: Parsers,
     container: Container,
     parentSourceDirective: string = undefined,
+    parentFreezeDirectiveActive: boolean = false,
     hasParentRule = false
 ): void => {
 
@@ -54,6 +55,11 @@ export const parseAtRules = (
                 parentSourceDirective
             );
 
+            const freezeDirectiveActive = (
+                checkDirective(controlDirectives, CONTROL_DIRECTIVE.FREEZE) ||
+                parentFreezeDirectiveActive
+            );
+
             if (
                 hasParentRule &&
                 node.nodes
@@ -62,6 +68,7 @@ export const parseAtRules = (
                     node,
                     hasParentRule,
                     sourceDirectiveValue,
+                    freezeDirectiveActive,
                     checkDirective(controlDirectives, CONTROL_DIRECTIVE.RULES),
                     checkDirective(controlDirectives, CONTROL_DIRECTIVE.URLS)
                 );
@@ -70,7 +77,8 @@ export const parseAtRules = (
             parsers.parseAtRules(
                 parsers,
                 node,
-                parentSourceDirective,
+                sourceDirectiveValue,
+                freezeDirectiveActive,
                 hasParentRule
             );
 
@@ -78,6 +86,7 @@ export const parseAtRules = (
                 parsers,
                 node,
                 sourceDirectiveValue,
+                freezeDirectiveActive,
                 hasParentRule
             );
 

--- a/src/parsers/declarations.ts
+++ b/src/parsers/declarations.ts
@@ -47,6 +47,7 @@ export const parseDeclarations = (
     container: DeclarationContainer,
     hasParentRule: boolean,
     ruleSourceDirectiveValue: string,
+    ruleFreezeDirectiveActive: boolean,
     processRule: boolean,
     rename: boolean
 ): void => {
@@ -151,11 +152,11 @@ export const parseDeclarations = (
                 return;
             }
 
-            const processUrlDirective = checkDirective(controlDirectives, CONTROL_DIRECTIVE.URLS);
+            const isProcessUrlDirectiveActive = checkDirective(controlDirectives, CONTROL_DIRECTIVE.URLS);
 
             const declString = `${decl.toString()};`;
             const declFlippedString = rtlcss.process(declString, {
-                processUrls: processUrls || processUrlDirective || rename,
+                processUrls: processUrls || isProcessUrlDirectiveActive || rename,
                 processEnv,
                 useCalc,
                 stringMap,
@@ -215,6 +216,18 @@ export const parseDeclarations = (
                 !sourceDirectiveValue ||
                 sourceDirectiveValue === source ||
                 mode === Mode.diff;
+
+            if (
+                checkDirective(controlDirectives, CONTROL_DIRECTIVE.FREEZE) ||
+                ruleFreezeDirectiveActive
+            ) {
+                if (mode === Mode.combined) {
+                    appendDeclarationToRule(decl, containerFlipped);
+                    declarationsProps.push(declPropUnprefixed);
+                    deleteDeclarations.push(decl);
+                }
+                return;
+            }
             
             if (
                 declProp === declFlippedProp &&

--- a/src/utilities/rules.ts
+++ b/src/utilities/rules.ts
@@ -231,7 +231,14 @@ export const removeEmptyRules = (rule: Container): void => {
 
 export const appendRules = (): void => {
     const { rules } = store;
-    rules.forEach(({rule, ruleLTR, ruleRTL, ruleBoth, ruleSafe}): void => {
+    rules.forEach((ruleObject): void => {
+        const {
+            rule,
+            ruleLTR,
+            ruleRTL,
+            ruleBoth,
+            ruleSafe
+        } = ruleObject;
         if (ruleBoth.nodes.length) {
             rule.after(ruleBoth);
         }
@@ -309,7 +316,7 @@ export const parseRuleNames = (): void => {
         let ruleFlippedSecond: Rule | undefined = undefined;
 
         for (const selector of rule.selectors) {
-            const flip = selector.replace(replaceRegExp, (match: string, group: string): string => replaceHash[group]);
+            const flip = selector.replace(replaceRegExp, (__match: string, group: string): string => replaceHash[group]);
             if (rulesHash[flip]) {
                 ruleFlippedSecond = rulesHash[flip].clone();
                 break;

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -66,13 +66,32 @@ export const addProperSelectorPrefixes = (
         source
     } = store.options;
     if (mode === Mode.combined) {
-        addSelectorPrefixes(ruleFlipped, source === Source.ltr ? ltrPrefix : rtlPrefix);
-        addSelectorPrefixes(ruleFlippedSecond, source === Source.rtl ? ltrPrefix : rtlPrefix);
+        addSelectorPrefixes(
+            ruleFlipped,
+            source === Source.ltr
+                ? ltrPrefix
+                : rtlPrefix
+        );
+        addSelectorPrefixes(
+            ruleFlippedSecond,
+            source === Source.ltr
+                ? rtlPrefix
+                : ltrPrefix
+        );
     } else {
-        addSelectorPrefixes(ruleFlipped, source === Source.ltr ? rtlPrefix : ltrPrefix);
-        addSelectorPrefixes(ruleFlippedSecond, source === Source.rtl ? rtlPrefix : ltrPrefix);
+        addSelectorPrefixes(
+            ruleFlipped,
+            source === Source.ltr
+                ? rtlPrefix
+                : ltrPrefix
+        );
+        addSelectorPrefixes(
+            ruleFlippedSecond,
+            source === Source.ltr
+                ? ltrPrefix
+                : rtlPrefix
+        );
     }
-
     addSelectorPrefixes(ruleBoth, bothPrefix);
     addSelectorPrefixes(ruleSafe, bothPrefix);
 };

--- a/tests/__snapshots__/basic-options/combined/basic.snapshot
+++ b/tests/__snapshots__/basic-options/combined/basic.snapshot
@@ -666,5 +666,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/combined/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/process-keyframes-true.snapshot
@@ -734,5 +734,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/combined/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/process-url-true.snapshot
@@ -678,5 +678,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/combined/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/source-rtl-and-process-keyframes-true.snapshot
@@ -734,5 +734,59 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="rtl"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="rtl"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="rtl"]:root .test60, [dir="rtl"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/combined/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/combined/source-rtl.snapshot
@@ -666,5 +666,59 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="rtl"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="rtl"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="rtl"]:root .test60, [dir="rtl"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/combined/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/combined/use-calc-true.snapshot
@@ -667,5 +667,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/diff/basic.snapshot
+++ b/tests/__snapshots__/basic-options/diff/basic.snapshot
@@ -205,5 +205,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/basic-options/diff/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/process-keyframes-true.snapshot
@@ -267,5 +267,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/basic-options/diff/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/process-url-true.snapshot
@@ -215,5 +215,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/basic-options/diff/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/source-rtl-and-process-keyframes-true.snapshot
@@ -267,5 +267,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/basic-options/diff/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/diff/source-rtl.snapshot
@@ -205,5 +205,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/basic-options/diff/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/diff/use-calc-true.snapshot
@@ -206,5 +206,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/basic-options/override/basic.snapshot
+++ b/tests/__snapshots__/basic-options/override/basic.snapshot
@@ -615,5 +615,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/override/process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/process-keyframes-true.snapshot
@@ -677,5 +677,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/override/process-url-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/process-url-true.snapshot
@@ -627,5 +627,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/override/source-rtl-and-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/source-rtl-and-process-keyframes-true.snapshot
@@ -671,5 +671,53 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/override/source-rtl.snapshot
+++ b/tests/__snapshots__/basic-options/override/source-rtl.snapshot
@@ -609,5 +609,53 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/basic-options/override/use-calc-true.snapshot
+++ b/tests/__snapshots__/basic-options/override/use-calc-true.snapshot
@@ -616,5 +616,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -680,5 +680,59 @@ html.rtl .test50, html.right-to-left .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.ltr .test54, .left-to-right .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+.ltr .test55, .left-to-right .test55, .ltr .test56, .left-to-right .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+.rtl .test55, .right-to-left .test55, .rtl .test56, .right-to-left .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+.ltr .test55, .left-to-right .test55, .rtl .test55, .right-to-left .test55, .ltr .test56, .left-to-right .test56, .rtl .test56, .right-to-left .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    .rtl .test57, .right-to-left .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .rtl .test58, .right-to-left .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html.ltr .test59, html.left-to-right .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+.ltr:root .test60, .left-to-right:root .test60, .ltr .test61, .left-to-right .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-and-rtl-prefix.snapshot
@@ -666,5 +666,59 @@ html.rtl .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.ltr .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+.ltr .test55, .ltr .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+.rtl .test55, .rtl .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+.ltr .test55, .rtl .test55, .ltr .test56, .rtl .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    .rtl .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .rtl .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html.ltr .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+.ltr:root .test60, .ltr .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/combined/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/combined/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -692,5 +692,59 @@ html.rtl .test50, html.right-to-left .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.ltr .test54, .left-to-right .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+.ltr .test55, .left-to-right .test55, .ltr .test56, .left-to-right .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+.rtl .test55, .right-to-left .test55, .rtl .test56, .right-to-left .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+.ltr .test55, .left-to-right .test55, .rtl .test55, .right-to-left .test55, .ltr .test56, .left-to-right .test56, .rtl .test56, .right-to-left .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    .rtl .test57, .right-to-left .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .rtl .test58, .right-to-left .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html.ltr .test59, html.left-to-right .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+.ltr:root .test60, .left-to-right:root .test60, .ltr .test61, .left-to-right .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -666,5 +666,59 @@ html.rtl .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.ltr.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+.ltr.test55, .ltr.test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+.rtl.test55, .rtl.test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+.ltr.test55, .rtl.test55, .ltr.test56, .rtl.test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    .rtl.test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .rtl.test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html.ltr .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+.ltr:root .test60, .ltr.test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/combined/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -666,5 +666,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] > .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] > .test55, [dir="ltr"] > .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] > .test55, [dir="rtl"] > .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] > .test55, [dir] > .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] > .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] > .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] > .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -205,5 +205,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-and-rtl-prefix.snapshot
@@ -205,5 +205,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/prefixes/diff/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/diff/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -215,5 +215,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -205,5 +205,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/diff/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -205,5 +205,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix-as-arrays.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix-as-arrays.snapshot
@@ -622,5 +622,53 @@ html.rtl .test50, html.right-to-left .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+.rtl .test55, .right-to-left .test55, .rtl .test56, .right-to-left .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-and-rtl-prefix.snapshot
@@ -615,5 +615,53 @@ html.rtl .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+.rtl .test55, .rtl .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/override/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
+++ b/tests/__snapshots__/prefixes/override/custom-ltr-rtl-and-both-prefix-as-arrays-and-process-urls-true.snapshot
@@ -634,5 +634,53 @@ html.rtl .test50, html.right-to-left .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+.rtl .test55, .right-to-left .test55, .rtl .test56, .right-to-left .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-custom-ltr-and-rtl-prefixes.snapshot
@@ -615,5 +615,53 @@ html.rtl .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+.rtl.test55, .rtl.test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-default-prefixes.snapshot
+++ b/tests/__snapshots__/prefixes/override/prefix-selector-transformer-with-default-prefixes.snapshot
@@ -615,5 +615,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] > .test55, [dir="rtl"] > .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-greedy-true.snapshot
@@ -674,5 +674,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -674,5 +674,59 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="rtl"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="rtl"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="rtl"]:root .test60, [dir="rtl"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -682,5 +682,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -682,5 +682,59 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="rtl"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="rtl"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="rtl"]:root .test60, [dir="rtl"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true-with-custom-string-map.snapshot
@@ -674,5 +674,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/combined/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/combined/process-rules-names-true.snapshot
@@ -666,5 +666,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-greedy-true.snapshot
@@ -213,5 +213,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -213,5 +213,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -221,5 +221,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -221,5 +221,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true-with-custom-string-map.snapshot
@@ -213,5 +213,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/rule-names/diff/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/diff/process-rules-names-true.snapshot
@@ -205,5 +205,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-greedy-true.snapshot
@@ -623,5 +623,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-source-rtl-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-source-rtl-greedy-true.snapshot
@@ -617,5 +617,53 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-and-greedy-true.snapshot
@@ -631,5 +631,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map-rtl-and-greedy-true.snapshot
@@ -625,5 +625,53 @@ html[dir="ltr"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true-with-custom-string-map.snapshot
@@ -623,5 +623,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/rule-names/override/process-rules-names-true.snapshot
+++ b/tests/__snapshots__/rule-names/override/process-rules-names-true.snapshot
@@ -615,5 +615,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -756,5 +756,59 @@ html[dir="rtl"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-process-urls-true.snapshot
@@ -700,5 +700,59 @@ html[dir="rtl"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true-rtl.snapshot
@@ -691,5 +691,59 @@ html[dir="ltr"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="rtl"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="rtl"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="rtl"]:root .test60, [dir="rtl"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/combined/safe-both-prefix-true.snapshot
@@ -691,5 +691,59 @@ html[dir="rtl"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -337,5 +337,13 @@ html .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test55, .test56 {
+    float: right;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-process-urls-true.snapshot
@@ -293,5 +293,13 @@ html .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test55, .test56 {
+    float: right;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true-rtl.snapshot
@@ -293,5 +293,13 @@ html .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test55, .test56 {
+    float: right;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/diff/safe-both-prefix-true.snapshot
@@ -293,5 +293,13 @@ html .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test55, .test56 {
+    float: right;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-keyframes-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-keyframes-true.snapshot
@@ -739,5 +739,56 @@ html[dir="rtl"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    z-index: 100;
+}
+
+[dir] .test55, [dir] .test56 {
+    float: left;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-urls-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-process-urls-true.snapshot
@@ -689,5 +689,56 @@ html[dir="rtl"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    z-index: 100;
+}
+
+[dir] .test55, [dir] .test56 {
+    float: left;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-rtl.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true-rtl.snapshot
@@ -671,5 +671,56 @@ html[dir="ltr"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    z-index: 100;
+}
+
+[dir] .test55, [dir] .test56 {
+    float: left;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true.snapshot
+++ b/tests/__snapshots__/safe-prefix/override/safe-both-prefix-true.snapshot
@@ -677,5 +677,56 @@ html[dir="rtl"] .test50 {
 [dir] .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    z-index: 100;
+}
+
+[dir] .test55, [dir] .test56 {
+    float: left;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -678,5 +678,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -678,5 +678,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/combined/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-string-map-process-urls-true.snapshot
@@ -678,5 +678,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/combined/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/combined/custom-string-map-without-names-process-urls-true.snapshot
@@ -678,5 +678,59 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+[dir="ltr"] .test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    z-index: 100;
+}
+
+[dir="ltr"] .test55, [dir="ltr"] .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+[dir] .test55, [dir] .test56 {
+    background-clip: text;
+    -webkit-background-clip: text;
+}
+
+@media only screen and (min-width: 630px) {
+    [dir="rtl"] .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    [dir="rtl"] .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html[dir="ltr"] .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+[dir="ltr"]:root .test60, [dir="ltr"] .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -215,5 +215,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -215,5 +215,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/string-map/diff/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-string-map-process-urls-true.snapshot
@@ -215,5 +215,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/string-map/diff/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/diff/custom-string-map-without-names-process-urls-true.snapshot
@@ -215,5 +215,11 @@ html .test50 {
     border-left: none;
     border-right: 1px solid #FFF;
     border: none;
+}
+
+.test55, .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
 }"
 `;

--- a/tests/__snapshots__/string-map/override/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-non-valid-string-different-lengths-map-process-urls-true.snapshot
@@ -627,5 +627,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/override/custom-non-valid-string-different-types-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-non-valid-string-different-types-map-process-urls-true.snapshot
@@ -627,5 +627,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/override/custom-string-map-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-string-map-process-urls-true.snapshot
@@ -627,5 +627,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/__snapshots__/string-map/override/custom-string-map-without-names-process-urls-true.snapshot
+++ b/tests/__snapshots__/string-map/override/custom-string-map-without-names-process-urls-true.snapshot
@@ -627,5 +627,53 @@ html[dir="rtl"] .test50 {
 .test53 {
     margin-block-start: 10px;
     margin-block-end: 5px;
+}
+
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+[dir="rtl"] .test55, [dir="rtl"] .test56 {
+    float: right;
+    margin: 10px 40px 30px 20px;
+    text-align: right;
+}
+
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
 }"
 `;

--- a/tests/css/input.css
+++ b/tests/css/input.css
@@ -458,3 +458,51 @@ html .test50 {
     margin-block-start: 10px;
     margin-block-end: 5px;
 }
+
+/*rtl:freeze*/
+.test54 {
+    background: gray;
+    color: red;
+    margin: 0px 2px 10px 5px;
+    padding-left: 10px;
+    text-align: right;
+}
+
+.test55, .test56 {
+    float: left;
+    /*rtl:begin:freeze*/
+    background: linear-gradient(180deg, #fff27e 0%, #ffffff 100%);
+    padding: 10px 5px 2px 20px;
+    /*rtl:end:freeze*/
+    background-clip: text;
+    -webkit-background-clip: text;
+    margin: 10px 20px 30px 40px;
+    text-align: left;
+    z-index: 100;
+}
+
+/*rtl:begin:source:rtl*/
+/*rtl:begin:freeze*/
+@media only screen and (min-width: 630px) {
+    .test57 {
+        text-align: right;
+        color: rgba(255, 242, 126, 1);
+    }
+    .test58 {
+        padding: 20px;
+        margin: auto;
+    }
+}
+/*rtl:end:source:rtl*/
+
+html .test59 {
+    border-radius: 5px;
+    text-align: left;
+}
+
+:root .test60, .test61 {
+    bottom: 20x;
+    margin: 10px 20px 30px;
+    z-index: 10;
+}
+/*rtl:end:freeze*/


### PR DESCRIPTION
This pull request implements new directives for freezing rules or delcrations.

| Directive                | Description                                                                                                                                    |
| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
| `/*rtl:freeze*/`         | Freezes the rule or declaration in the current direction<br>but does nothing with the counterpart direction<br>if there are flippable declarations     |
| `/*rtl:begin:freeze*/`   | Starts a freeze block                                                                                             |
| `/*rtl:end:freeze*/`     | Ends a freeze block                                                                                               |

#### `/*rtl:freeze*/`

<details><summary>Expand</summary>
<p>

>[!IMPORTANT]
>This directive only works in `combined` mode. If you use it in `override` or `diff` mode it will be ignored.

This directive freezes the rule or declaration in the current direction but does nothing with the counterpart direction if there are flippable declarations. When used with a rule, it will freeze it in the current direction even if it is doesn't contain flippable declarations. When it is used in a declration, it will freeze the declaration in the current direction even if it is not flippable.

##### input

```css
/*rtl:freeze*/
.test1, .test2 {
    color: red;
    text-align: left;
    left: 10px;
}

.test3 {
    /*rtl:freeze*/
    text-align: center;
    /*rtl:freeze*/
    padding: 10px 20px 30px 40px;
    margin: 1px 2px 3px 4px;
}
```

##### output

```css
[dir="ltr"] .test1, [dir="ltr"] .test2 {
    color: red;
    text-align: left;
    left: 10px;
}

[dir="ltr"] .test3 {
    text-align: center;
    padding: 10px 40px 30px 20px;
    margin: 1px 4px 3px 2px;
}

[dir="rtl"] .test3 {
    margin: 1px 4px 3px 2px;
}
```

</p>

</details>

---

#### `/*rtl:begin:freeze*/` and `/*rtl:end:freeze*/`

<details><summary>Expand</summary>
<p>

>[!IMPORTANT]
>This directive only works in `combined` mode. If you use it in `override` or `diff` mode it will be ignored.

These directives should be used together, they will provide the beginning and the end for freezing rules or declarations. The rules or delclarations between these blocks, will be frozen in the current direction even if there are no flippable declarations involved.

Freezing multiple rules:

##### input

```css
/*rtl:begin:freeze*/
.test1, .test2 {
    color: #FFF;
    left: 10px;
    text-align: left;
}

.test3 {
    padding: 1px 2px 3px 4px;
}
/*rtl:end:freeze*/
```

##### output

```css
[dir="ltr"] .test1, [dir="ltr"] .test2 {
    color: #FFF;
    left: 10px;
    text-align: left;
}

[dir="ltr"] .test3 {
    padding: 1px 2px 3px 4px;
}
```

Freezing multiple declarations:

##### input

```css
.test1, .test2 {
    color: red;
    left: 10px;
    /*rtl:begin:freeze*/
    margin-left: 4em;
    padding: 1px 2px 3px 4px;
    /*rtl:end:freeze*/
    text-align: left;
}
```

##### output

```css
.test1, .test2 {
    color: red;
}

[dir="ltr"] .test1, [dir="ltr"] .test2 {
    left: 10px;
    margin-left: 4em;
    padding: 1px 2px 3px 4px;
    text-align: left;
}

[dir="rtl"] .test1, [dir="rtl"] .test2 {
    right: 10px;
    text-align: right;
}
```

</p>

</details>