### PR TITLE
Check if a Rule has a selectors property before accessing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.6.1] - 2025-04-07
+
+- Check that a rule has a `selectors` property before accessing it and in this way avoid an issue with Tailwind.
+
 ## [5.6.0] - 2024-12-13
 
 - Add new directives to freeze rules and declarations `/*rtl:freeze*/`, `/*rtl:begin:freeze*/` and `/*rtl:end:freeze*/`

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -28,23 +28,26 @@ const addPrefix = (prefix: string, selector: string): string => {
 };
 
 export const addSelectorPrefixes = (rule: Rule, prefixes: strings): void => {
-    rule.selectors = isString(prefixes)
-        ? rule.selectors.map((selector: string): string => {
-            if (store.rulesPrefixRegExp.test(selector)) {
-                return selector;
-            }
-            return addPrefix(prefixes, selector);
-        })
-        : rule.selectors.reduce((selectors: string[], selector: string): string[] => {
-            if (store.rulesPrefixRegExp.test(selector)) {
-                selectors = [...selectors, selector];
-            } else {
-                selectors = selectors.concat(
-                    prefixes.map((prefix: string): string => addPrefix(prefix, selector))
-                );
-            }
-            return selectors;
-        }, []);
+    
+    if (rule.selectors) {
+        rule.selectors = isString(prefixes)
+            ? rule.selectors.map((selector: string): string => {
+                if (store.rulesPrefixRegExp.test(selector)) {
+                    return selector;
+                }
+                return addPrefix(prefixes, selector);
+            })
+            : rule.selectors.reduce((selectors: string[], selector: string): string[] => {
+                if (store.rulesPrefixRegExp.test(selector)) {
+                    selectors = [...selectors, selector];
+                } else {
+                    selectors = selectors.concat(
+                        prefixes.map((prefix: string): string => addPrefix(prefix, selector))
+                    );
+                }
+                return selectors;
+            }, []);
+    }
 };
 
 export const hasSelectorsPrefixed = (rule: Rule): boolean => {


### PR DESCRIPTION
This pull request adds a check to verify if a rule has a `selectors` property before accessing it. For some reason it is impossible to reproduce this using a regular `CSS`, but if the `CSS` is created by `Tailwind`, some `Rules` don't have this property. (pretty similar to [this](https://github.com/elchininet/postcss-rtlcss/issues/110#issuecomment-993878002)). Instead of investigating why this occurs, it is better to add a check at the beginning and avoid the failure because it doesn't hurt to have it there.

```bash
[postcss] Cannot read properties of undefined (reading 'map')
```