### PR TITLE
Fix an issue with Tailwind and multiple at-rules

### DIFF
--- a/src/utilities/rules.ts
+++ b/src/utilities/rules.ts
@@ -48,8 +48,15 @@ export const ruleHasChildren = (rule: Container): boolean => {
 
 export const getParentContainers = (container: DeclarationContainer): DeclarationContainer[] => {
     const containers: DeclarationContainer[] = [];
+    const temp: DeclarationContainer[] = [];
     while (isDeclarationContainer(container)) {
-        containers.unshift(container);
+        
+        if (isRule(container)) {
+            containers.unshift(container, ...temp.splice(0));
+        } else {
+            temp.unshift(container);
+        }
+
         container = container.parent as DeclarationContainer;
     }
     containers.pop();

--- a/src/utilities/selectors.ts
+++ b/src/utilities/selectors.ts
@@ -28,26 +28,23 @@ const addPrefix = (prefix: string, selector: string): string => {
 };
 
 export const addSelectorPrefixes = (rule: Rule, prefixes: strings): void => {
-    
-    if (rule.selectors) {
-        rule.selectors = isString(prefixes)
-            ? rule.selectors.map((selector: string): string => {
-                if (store.rulesPrefixRegExp.test(selector)) {
-                    return selector;
-                }
-                return addPrefix(prefixes, selector);
-            })
-            : rule.selectors.reduce((selectors: string[], selector: string): string[] => {
-                if (store.rulesPrefixRegExp.test(selector)) {
-                    selectors = [...selectors, selector];
-                } else {
-                    selectors = selectors.concat(
-                        prefixes.map((prefix: string): string => addPrefix(prefix, selector))
-                    );
-                }
-                return selectors;
-            }, []);
-    }
+    rule.selectors = isString(prefixes)
+        ? rule.selectors.map((selector: string): string => {
+            if (store.rulesPrefixRegExp.test(selector)) {
+                return selector;
+            }
+            return addPrefix(prefixes, selector);
+        })
+        : rule.selectors.reduce((selectors: string[], selector: string): string[] => {
+            if (store.rulesPrefixRegExp.test(selector)) {
+                selectors = [...selectors, selector];
+            } else {
+                selectors = selectors.concat(
+                    prefixes.map((prefix: string): string => addPrefix(prefix, selector))
+                );
+            }
+            return selectors;
+        }, []);
 };
 
 export const hasSelectorsPrefixed = (rule: Rule): boolean => {

--- a/tests/__snapshots__/nested-rules/combined/source-ltr-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-ltr-process-rule-names-true.snapshot
@@ -239,5 +239,19 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} processRuleNames:
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  [dir="ltr"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="rtl"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/combined/source-ltr.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-ltr.snapshot
@@ -231,5 +231,19 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: ltr} 1`] = `
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  [dir="ltr"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="rtl"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/combined/source-rtl-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-rtl-process-rule-names-true.snapshot
@@ -239,5 +239,19 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} processRuleNames:
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  [dir="rtl"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="ltr"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/combined/source-rtl.snapshot
+++ b/tests/__snapshots__/nested-rules/combined/source-rtl.snapshot
@@ -231,5 +231,19 @@ exports[`[[Mode: combined]] Nested rules tests:  {source: rtl} 1`] = `
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  [dir="rtl"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="ltr"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/diff/source-ltr-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-ltr-process-rule-names-true.snapshot
@@ -98,5 +98,14 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: ltr} processRuleNames: tru
 
 @mixin padding {
     padding-left: 10px;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/diff/source-ltr.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-ltr.snapshot
@@ -90,5 +90,14 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: ltr} 1`] = `
 
 @mixin padding {
     padding-left: 10px;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/diff/source-rtl-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-rtl-process-rule-names-true.snapshot
@@ -98,5 +98,14 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: rtl} processRuleNames: tru
 
 @mixin padding {
     padding-left: 10px;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/diff/source-rtl.snapshot
+++ b/tests/__snapshots__/nested-rules/diff/source-rtl.snapshot
@@ -90,5 +90,14 @@ exports[`[[Mode: diff]] Nested rules tests:  {source: rtl} 1`] = `
 
 @mixin padding {
     padding-left: 10px;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/override/source-ltr-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-ltr-process-rule-names-true.snapshot
@@ -203,5 +203,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} processRuleNames:
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="rtl"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/override/source-ltr.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-ltr.snapshot
@@ -195,5 +195,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: ltr} 1`] = `
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="rtl"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/override/source-rtl-process-rule-names-true.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-rtl-process-rule-names-true.snapshot
@@ -203,5 +203,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} processRuleNames:
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="ltr"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/__snapshots__/nested-rules/override/source-rtl.snapshot
+++ b/tests/__snapshots__/nested-rules/override/source-rtl.snapshot
@@ -195,5 +195,20 @@ exports[`[[Mode: override]] Nested rules tests:  {source: rtl} 1`] = `
 
 .test14 {
    @include padding;
+}
+
+@layer utilities {
+  .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+
+  [dir="ltr"] .sm\\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: 0;
+      padding-right: calc(var(--spacing) * 8);
+    }
+  }
 }"
 `;

--- a/tests/css/input-nested.scss
+++ b/tests/css/input-nested.scss
@@ -100,3 +100,11 @@
 .test14 {
    @include padding;
 }
+
+@layer utilities {
+  .sm\:pl-8 {
+    @media (width >= 40rem) {
+      padding-left: calc(var(--spacing) * 8);
+    }
+  }
+}


### PR DESCRIPTION
This pull request fixes an issue related to multiple nested at-rules with rules in the middle. [This previous fix](https://github.com/elchininet/postcss-rtlcss/issues/492) was to avoid an error coming from Tailwind but that patch was not a fix in reality, it just hid the error. In this pull request, the management of multiple nested at-rules with rules in the middle has been fixed so the previous patch has been removed.

Closes: #520 