### PR TITLE
Test and build playground from Github workflows

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -1,0 +1,52 @@
+name: Deploy Playground to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-playground:
+    name: Build Playground
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+          run_install: false
+      - name: Set-up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build Playground
+        run: pnpm playground:build
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs/
+
+  deploy-playground:
+    name: Deploy Playground
+    needs: build-playground
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Deployment
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,8 @@ jobs:
         run: pnpm install --ignore-scripts --prefer-offline
       - name: Linting files
         run: pnpm lint
+      - name: Test playground build
+        run: pnpm playground:build
       - name: Make coverage
         run: pnpm test --coverage
       - name: Coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+docs/
 .DS_Store
 coverage/
 /esm/


### PR DESCRIPTION
This pull request adds a new step in the tests to build the Playground and to ensure that every commit or dependency update doesn't break it. Also, a new workflow has been created to deploy to Github pages the Playground assets on every marge to master, this ensures that the Playground is kept up to date with dependencies changes.