### PR TITLE
Remove Playground Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,30 +13,12 @@ updates:
       - dependency-name: "postcss"
       - dependency-name: "postcss-preset-env"
     groups:
-      dependencies-dev:
-        dependency-type: "development"
-    labels:
-      - dependencies
-    versioning-strategy: increase
-  - package-ecosystem: "npm"
-    directory: "/playground/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-      timezone: "Europe/Amsterdam"
-    commit-message:
-      prefix: "[Playground dependencies]"
-    ignore:
-      - dependency-name: "postcss"
-    groups:
       dependencies-prod:
         dependency-type: "production"
       dependencies-dev:
         dependency-type: "development"
     labels:
       - dependencies
-      - playground
     versioning-strategy: increase
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
As the project has been migrated to a workspace, the Playground Dependabot configuration is not needed anymore because both `package.json` [will be updated in the same Dependabot pull request](https://github.com/elchininet/postcss-rtlcss/pull/671).