### PR TITLE
Set cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "sunday"
       time: "09:00"
       timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 1
     commit-message:
       prefix: "[Dependencies]"
     ignore:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,11 +5,6 @@ allowBuilds:
   '@parcel/watcher': false
   esbuild: false
   unrs-resolver: false
-minimumReleaseAgeExclude:
-  - dompurify@3.4.0
-  - esbuild@0.25.0
-  - uuid@11.1.1
-  - qs@6.15.2
 overrides:
   dompurify@<3.4.0: ^3.4.0
   esbuild@<=0.24.2: ^0.25.0


### PR DESCRIPTION
This pull request sets [a cooldown period](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) in the Depndabot configuration to avoid the `pnpm` `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` error because Dependabot updates packages that have been released before the `pnpm` minimum release age.