### PR TITLE
Fix Playground because of a deprecated feature

### DIFF
--- a/playground/src/components/CSSPanel/CSSPanel.tsx
+++ b/playground/src/components/CSSPanel/CSSPanel.tsx
@@ -3,7 +3,7 @@ import React, {
     useRef,
     JSX
 } from 'react';
-import { editor, languages } from 'monaco-editor';
+import { editor, css } from 'monaco-editor';
 import * as styles from './CSSPanel.module.css';
 
 export interface CSSPanelProps {
@@ -24,8 +24,7 @@ export const CSSPanel = (props: CSSPanelProps): JSX.Element => {
 
     useEffect(() => {
 
-        // @ts-expect-error this needs to be migrated because css property is deprecated
-        languages.css.cssDefaults.setModeConfiguration({
+        css.cssDefaults.setModeConfiguration({
             colors: false
         });
 
@@ -45,7 +44,7 @@ export const CSSPanel = (props: CSSPanelProps): JSX.Element => {
                 enabled: false
             },
             hover: {
-                enabled: false
+                enabled: 'off'
             },
             scrollBeyondLastLine: false,
             language: 'scss'


### PR DESCRIPTION
The nested namespace `languages.css` [was deprecated since version `0.56.0`](https://github.com/microsoft/monaco-editor/blob/main/CHANGELOG.md#breaking-changes-1). And it was removed entirely so the Playground was failing. This pull request migrates this.