### PR TITLE
Fix Playground error

### DIFF
--- a/playground/.babelrc
+++ b/playground/.babelrc
@@ -1,7 +1,12 @@
 {
     "presets": [        
         "@babel/preset-env",
-        "@babel/preset-react",
+        [
+            "@babel/preset-react",
+            {
+                "runtime": "classic"
+            }
+        ],
         "@babel/preset-typescript"
     ]
 }


### PR DESCRIPTION
This pull request fixes a Playground error related to `@babel/preset-react` runtime.

More context: https://github.com/babel/babel/discussions/13013